### PR TITLE
Correct the XdgAutoStart behavior

### DIFF
--- a/libraries/qtxdg/xdgdesktopfile.cpp
+++ b/libraries/qtxdg/xdgdesktopfile.cpp
@@ -747,9 +747,23 @@ bool XdgDesktopFile::isShow(const QString& environment) const
     if (value("NoDisplay").toBool())
         return false;
 
+    // The file is inapplicable to the current environment
+    if (!isApplicable(true, environment))
+        return false;
+
+    d->mIsShow = True;
+    return true;
+}
+
+
+/************************************************
+
+ ************************************************/
+bool XdgDesktopFile::isApplicable(bool excludeHidden, const QString& environment) const
+{
     // Hidden should have been called Deleted. It means the user deleted
     // (at his level) something that was present
-    if (value("Hidden").toBool())
+    if (excludeHidden && value("Hidden").toBool())
         return false;
 
     // A list of strings identifying the environments that should display/not
@@ -775,7 +789,6 @@ bool XdgDesktopFile::isShow(const QString& environment) const
     if (!s.isEmpty() && ! checkTryExec(s))
         return false;
 
-    d->mIsShow = True;
     return true;
 }
 

--- a/libraries/qtxdg/xdgdesktopfile.h
+++ b/libraries/qtxdg/xdgdesktopfile.h
@@ -157,6 +157,12 @@ public:
          checks whether to display a this application or not. */
     bool isShow(const QString& environment = "RAZOR") const;
 
+    /*! This fuction returns true if the desktop file is applicable to the current environment.
+        @par excludeHidden - if set to true (default), files with "Hidden=true" will be considered "not applicable".
+                             Setting this to false is be useful when the user wants to enable/disable items and wants to see those
+                             that are Hidden */
+    bool isApplicable(bool excludeHidden = true, const QString& environment = "RAZOR") const;
+
 protected:
     virtual QString prefix() const { return "Desktop Entry"; }
     virtual bool check() const { return true; }

--- a/libraries/razorqt/xdgautostart.h
+++ b/libraries/razorqt/xdgautostart.h
@@ -52,15 +52,14 @@ public:
     XdgAutoStart();
     ~XdgAutoStart();
     QList<XdgDesktopFile*> list();
+    QMap< QString, XdgDesktopFile* > map();
 
 private:
-    QList<XdgDesktopFile*> m_list;
-    QStringList badNames;
+    QMap<QString, XdgDesktopFile*> mMap;
 
     void updateList();
     void addDirtoList(const QString & _dir);
     void debugAutostart();
-    void cleanList();
 };
 
 


### PR DESCRIPTION
- The spec says that files with the same filename override each other, not files with the same "Name" entry.
- AutoStart files should not care if "NoDisplay" is set.

I'm currently working on improving Razor's Autostart (to make it similar Xfce's), so while this seems like a corner case, the modifications made here will be used in the code I'm currently working on.
