### PR TITLE
Replaces return"" by return QString()

### DIFF
--- a/libraries/qtxdg/xdgdesktopfile.cpp
+++ b/libraries/qtxdg/xdgdesktopfile.cpp
@@ -804,7 +804,7 @@ QString expandDynamicUrl(QString url)
 QString XdgDesktopFile::url() const
 {
     if (type() != LinkType)
-        return "";
+        return QString();
 
    QString url;
 
@@ -817,7 +817,7 @@ QString XdgDesktopFile::url() const
     if (!url.isEmpty())
         return url;
 
-    return "";
+    return QString();
 }
 
 
@@ -846,7 +846,7 @@ QString findDesktopFile(const QString& dirName, const QString& desktopName)
         }
     }
 
-    return "";
+    return QString();
 }
 
 
@@ -865,7 +865,7 @@ QString findDesktopFile(const QString& desktopName)
             return f;
     }
 
-    return "";
+    return QString();
 }
 
 

--- a/libraries/qtxdg/xdgmenu.cpp
+++ b/libraries/qtxdg/xdgmenu.cpp
@@ -751,7 +751,7 @@ QString XdgMenu::getMenuFileName(const QString& baseName)
     }
 
 
-    return "";
+    return QString();
 }
 
 

--- a/libraries/razormount/diskmonitor.cpp
+++ b/libraries/razormount/diskmonitor.cpp
@@ -99,7 +99,7 @@ QString DiskInfo::iconName() const
     else if (raw_info["DKD_PRESENTATION_ICON_NAME"] == "multimedia-player")
         return "multimedia-player";
 
-    return "";
+    return QString();
 }
 
 DiskMonitor::DiskMonitor(QObject *parent) : QThread(parent)

--- a/libraries/razorqt/razorsettings.cpp
+++ b/libraries/razorqt/razorsettings.cpp
@@ -120,7 +120,7 @@ QString findFile(const QString& fileName, bool onlyGlobal = false)
             return file;
     }
 
-    return "";
+    return QString();
 }
 
 
@@ -287,7 +287,7 @@ QString RazorTheme::qss(const QString& module) const
         return d->loadQss(path);
 
     qWarning() << "QSS file cannot be found in any location:" << QString("%1/%2.qss").arg(d->mThemeName, module);
-    return "";
+    return QString();
 }
 
 
@@ -300,14 +300,14 @@ QString RazorThemePrivate::loadQss(const QString& qssFile) const
     if (! f.open(QIODevice::ReadOnly | QIODevice::Text))
     {
         qWarning() << "Theme: Canot open file for reading:" << qssFile;
-        return "";
+        return QString();
     }
 
     QString qss = f.readAll();
     f.close();
 
     if (qss.isEmpty())
-        return "";
+        return QString();
 
     // handle relative paths
     QString qssDir = QFileInfo(qssFile).canonicalPath();
@@ -326,7 +326,7 @@ QString RazorTheme::desktopBackground(int screen) const
     QString wallpapperCfgFileName = findFile(QString("themes/%1/wallpapper.cfg").arg(d->mThemeName));
 
     if (wallpapperCfgFileName.isEmpty())
-        return "";
+        return QString();
 
     QSettings s(wallpapperCfgFileName, QSettings::IniFormat);
     QString themeDir = QFileInfo(wallpapperCfgFileName).absolutePath();

--- a/razorqt-panel/panel/razorpanel.cpp
+++ b/razorqt-panel/panel/razorpanel.cpp
@@ -100,7 +100,7 @@ QString positionToStr(RazorPanel::Position position)
         case RazorPanel::PositionBottom: return QString("Bottom");
     }
 
-    return "";
+    return QString();
 }
 
 

--- a/razorqt-session/src/wmselectdialog.cpp
+++ b/razorqt-session/src/wmselectdialog.cpp
@@ -64,7 +64,7 @@ QString WmSelectDialog::windowManager() const
     if (item)
         return item->data(Qt::UserRole).toString();
 
-    return "";
+    return QString();
 }
 
 void WmSelectDialog::addWindowManager(const QString &program, const QString &description)


### PR DESCRIPTION
It's faster and cleaner.
        QString().isEmpty();            // returns true
        QString().isNull();               // returns true
So replacing "" by QString() will not brake existing code.

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
