### PR TITLE
Clean up configure panel dialog

### DIFF
--- a/razorqt-panel/panel/configpaneldialog.h
+++ b/razorqt-panel/panel/configpaneldialog.h
@@ -25,13 +25,14 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#include "razorpanelplugin_p.h"
-#include <razorqt/razorplugininfo.h>
-
 #ifndef CONFIGPANELDIALOG_H
 #define CONFIGPANELDIALOG_H
 
-#include <QDialog>
+#include "razorpanel.h"
+#include <razorqt/razorsettings.h>
+
+#include <QtGui/QDialog>
+#include <QtGui/QAbstractButton>
 
 namespace Ui {
 class ConfigPanelDialog;
@@ -42,28 +43,33 @@ class ConfigPanelDialog : public QDialog
     Q_OBJECT
     
 public:
-    explicit ConfigPanelDialog(int hDefault, int wMax, QWidget *parent = 0);
+    explicit ConfigPanelDialog(int hDefault, int wMax, RazorSettings *settings, QWidget *parent = 0);
     ~ConfigPanelDialog();
 
-public slots:
-    void saveSettings();
+signals:
+    void configChanged(int height, int width, bool percent, RazorPanel::Alignment);
+
+private slots:
+    void dialogButtonsAction(QAbstractButton *button);
     void spinBoxHeightValueChanged(int q);
     void spinBoxWidthValueChanged(int q);
     void comboBoxWidthTypeIndexChanged(int q);
     void comboBoxAlignmentIndexChanged(int q);
 
-    
 private:
     Ui::ConfigPanelDialog *ui;
     QString mConfigFile;
     RazorSettings* mSettings;
+    RazorSettingsCache *mCache;
     int mHeightDefault;
     int mHeight;
     int mWidthMax;
-    int mWidthType;
     int mWidth;
-    int mAlignment;
+    bool mWidthInPercents;
+    RazorPanel::Alignment mAlignment;
 
+    void initControls();
+    void closeEvent(QCloseEvent *event);
 };
 
 #endif // CONFIGPANELDIALOG_H

--- a/razorqt-panel/panel/configpaneldialog.ui
+++ b/razorqt-panel/panel/configpaneldialog.ui
@@ -10,150 +10,99 @@
     <height>141</height>
    </rect>
   </property>
-  <property name="minimumSize">
-   <size>
-    <width>260</width>
-    <height>141</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>260</width>
-    <height>141</height>
-   </size>
-  </property>
   <property name="windowTitle">
    <string>Configure panel</string>
   </property>
-  <widget class="QLabel" name="label">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>15</y>
-     <width>31</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Height:</string>
-   </property>
-  </widget>
-  <widget class="QSpinBox" name="spinBox_height">
-   <property name="geometry">
-    <rect>
-     <x>90</x>
-     <y>10</y>
-     <width>101</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <property name="minimum">
-    <number>1</number>
-   </property>
-   <property name="maximum">
-    <number>250</number>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="okButton">
-   <property name="geometry">
-    <rect>
-     <x>170</x>
-     <y>110</y>
-     <width>80</width>
-     <height>24</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>OK</string>
-   </property>
-  </widget>
-  <widget class="QComboBox" name="comboBox_widthType">
-   <property name="geometry">
-    <rect>
-     <x>200</x>
-     <y>40</y>
-     <width>41</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <item>
-    <property name="text">
-     <string>%</string>
-    </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Height:</string>
+     </property>
+    </widget>
    </item>
-   <item>
-    <property name="text">
-     <string>px</string>
-    </property>
+   <item row="1" column="5">
+    <widget class="QComboBox" name="comboBox_widthType">
+     <item>
+      <property name="text">
+       <string>%</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>px</string>
+      </property>
+     </item>
+    </widget>
    </item>
-  </widget>
-  <widget class="QLabel" name="label_2">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>45</y>
-     <width>31</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Width:</string>
-   </property>
-  </widget>
-  <widget class="QSpinBox" name="spinBox_width">
-   <property name="geometry">
-    <rect>
-     <x>90</x>
-     <y>40</y>
-     <width>101</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <property name="minimum">
-    <number>1</number>
-   </property>
-   <property name="maximum">
-    <number>250</number>
-   </property>
-  </widget>
-  <widget class="QComboBox" name="comboBox_alignment">
-   <property name="geometry">
-    <rect>
-     <x>90</x>
-     <y>70</y>
-     <width>101</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <item>
-    <property name="text">
-     <string>Left</string>
-    </property>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Alignment:</string>
+     </property>
+    </widget>
    </item>
-   <item>
-    <property name="text">
-     <string>Right</string>
-    </property>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Width:</string>
+     </property>
+    </widget>
    </item>
-   <item>
-    <property name="text">
-     <string>Center</string>
-    </property>
+   <item row="1" column="1" colspan="4">
+    <widget class="QSpinBox" name="spinBox_width">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+    </widget>
    </item>
-  </widget>
-  <widget class="QLabel" name="label_3">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>75</y>
-     <width>61</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Alignment</string>
-   </property>
-  </widget>
+   <item row="0" column="1" colspan="4">
+    <widget class="QSpinBox" name="spinBox_height">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="4">
+    <widget class="QComboBox" name="comboBox_alignment">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>Left</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Center</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Right</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="6">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="5">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>px</string>
+     </property>
+     <property name="indent">
+      <number>5</number>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/razorqt-panel/panel/razorpanel.cpp
+++ b/razorqt-panel/panel/razorpanel.cpp
@@ -64,7 +64,7 @@
 #define CFG_KEY_PLUGINS     "plugins"
 #define CFG_KEY_HEIGHT      "height"
 #define CFG_KEY_WIDTH       "width"
-#define CFG_KEY_WIDTH_TYPE  "widthType"
+#define CFG_KEY_PERCENT     "width-percent"
 #define CFG_KEY_ALIGNMENT   "alignment"
 
 
@@ -176,6 +176,10 @@ void RazorPanelPrivate::init()
     mSettings->beginGroup(CFG_PANEL_GROUP);
     mPosition = strToPosition(mSettings->value(CFG_KEY_POSITION).toString(), RazorPanel::PositionBottom);
     mScreenNum = mSettings->value(CFG_KEY_SCREENNUM, QApplication::desktop()->primaryScreen()).toInt();
+    mHeight = mSettings->value(CFG_KEY_HEIGHT, q->sizeHint().height()).toInt();
+    mAlignment = RazorPanel::Alignment(mSettings->value(CFG_KEY_ALIGNMENT, 0).toInt());
+    mWidthInPercents = mSettings->value(CFG_KEY_PERCENT, true).toBool();
+    mWidth = mSettings->value(CFG_KEY_WIDTH, 100).toInt();
     mSettings->endGroup();
 
     q->setLayout(mLayout);
@@ -355,56 +359,14 @@ void RazorPanelPrivate::realign()
     QRect rect = screen;
     QSize sizeHint = q->sizeHint();
 
-    // Panel height: load from file, else - use default
-    mSettings->beginGroup(CFG_PANEL_GROUP);
-    int mHeight = mSettings->value(CFG_KEY_HEIGHT, sizeHint.height()).toInt();
-    int mWidthType = mSettings->value(CFG_KEY_WIDTH_TYPE, 0).toInt();
-    int mWidth = mSettings->value(CFG_KEY_WIDTH, 100).toInt();
-    int mAlignment = mSettings->value(CFG_KEY_ALIGNMENT, 0).toInt();
-    mSettings->endGroup();
-
     switch (mPosition)
     {
         case RazorPanel::PositionTop:
-        rect.setHeight(mHeight);
-
-        if (mWidthType==0)   // size in percents
-        {
-            if (mAlignment==2)      //align - center
-                rect.setLeft((screen.width()-(screen.width()*mWidth/100))/2);
-            if (mAlignment==1) //align - rigth
-                rect.setLeft(screen.width()-(screen.width()*mWidth/100));
-            rect.setWidth(screen.width()*mWidth/100);
-        }
-        else                // size in pixels
-        {
-            if (mAlignment==2)      //align - center
-                rect.setLeft((screen.width()-mWidth)/2);
-            if (mAlignment==1) //align - rigth
-                rect.setLeft(screen.width()-mWidth);
-            rect.setWidth(mWidth);
-        }
+            rect.setHeight(mHeight);
             break;
 
         case RazorPanel::PositionBottom:
             rect.setHeight(mHeight);
-
-            if (mWidthType==0)   // size in percents
-            {
-                if (mAlignment==2)      //align - center
-                    rect.setLeft((screen.width()-(screen.width()*mWidth/100))/2);
-                if (mAlignment==1) //align - rigth
-                    rect.setLeft(screen.width()-(screen.width()*mWidth/100));
-                rect.setWidth(screen.width()*mWidth/100);
-            }
-            else                // size in pixels
-            {
-                if (mAlignment==2)      //align - center
-                    rect.setLeft((screen.width()-mWidth)/2);
-                if (mAlignment==1) //align - rigth
-                    rect.setLeft(screen.width()-mWidth);
-                rect.setWidth(mWidth);
-            }
             rect.moveBottom(screen.bottom());
             break;
 
@@ -417,6 +379,16 @@ void RazorPanelPrivate::realign()
             rect.moveRight(screen.right());
             break;
     }
+
+    int width = mWidth;
+    if (mWidthInPercents)
+        width = screen.width() * width / 100;
+
+    if (mAlignment == RazorPanel::AlignmentCenter)
+        rect.setLeft((screen.width() - width) / 2);
+    else if (mAlignment == RazorPanel::AlignmentRight)
+        rect.setLeft(screen.width() - width);
+    rect.setWidth(width);
 
     q->setGeometry(rect);
 
@@ -619,15 +591,24 @@ void RazorPanelPrivate::showConfigPanelDialog()
 {
     Q_Q(RazorPanel);
     QRect screen = QApplication::desktop()->screenGeometry(mScreenNum);
-    QSize sizeHint = q->sizeHint();
-
-    int heightDefault=sizeHint.height();
-    int widthMax=screen.width();
-    ConfigPanelDialog* dlg = new ConfigPanelDialog (heightDefault, widthMax, q);
+    ConfigPanelDialog* dlg = new ConfigPanelDialog (mHeight, screen.width(), mSettings, q);
     dlg->setAttribute(Qt::WA_DeleteOnClose);
-    //dlg->exec();
+    connect(dlg, SIGNAL(configChanged(int, int, bool, RazorPanel::Alignment)),
+                      SLOT(updateSize(int, int, bool, RazorPanel::Alignment)));
     dlg->show();
+}
 
+
+/************************************************
+
+ ************************************************/
+void RazorPanelPrivate::updateSize(int height, int width, bool percent, RazorPanel::Alignment alignment)
+{
+    mHeight = height;
+    mWidth = width;
+    mWidthInPercents = percent;
+    mAlignment = alignment;
+    realign();
 }
 
 /************************************************

--- a/razorqt-panel/panel/razorpanel.h
+++ b/razorqt-panel/panel/razorpanel.h
@@ -54,6 +54,12 @@ public:
         PositionRight
     };
 
+    enum Alignment {
+        AlignmentLeft   = -1,
+        AlignmentCenter =  0,
+        AlignmentRight  =  1
+    };
+
     RazorPanel(QWidget *parent = 0);
     virtual ~RazorPanel();
 

--- a/razorqt-panel/panel/razorpanel_p.h
+++ b/razorqt-panel/panel/razorpanel_p.h
@@ -74,6 +74,7 @@ public slots:
     void onRemovePlugin();
     void onMovePlugin();
     void startMoveWidget();
+    void updateSize(int height, int width, bool percent, RazorPanel::Alignment alignment);
 
 private:
     void loadPlugins();
@@ -85,6 +86,10 @@ private:
     Q_DECLARE_PUBLIC(RazorPanel)
 
     RazorPanel::Position mPosition;
+    RazorPanel::Alignment mAlignment;
+    int mHeight;
+    int mWidth;
+    bool mWidthInPercents;
     int mScreenNum;
     QString mConfigFile;
     RazorSettings* mSettings;


### PR DESCRIPTION
Specific changes:
- Use the "standard" Razor config dialog Close/Reset logic
- Use a flexible layout so that text is not cut off with larger fonts
- Change config entries to make them more human-readable
- Simplify unnecessarily complicated/duplicated code
