### PR TITLE
Lock the screen when "Lock Screen" is selected

### DIFF
--- a/libraries/razorqt/screensaver.cpp
+++ b/libraries/razorqt/screensaver.cpp
@@ -55,7 +55,7 @@ QList<QAction*> ScreenSaver::availableActions()
 
 void ScreenSaver::lockScreen()
 {
-    m_xdgProcess->start("xdg-screensaver", QStringList() << "activate");
+    m_xdgProcess->start("xdg-screensaver", QStringList() << "lock");
 }
 
 void ScreenSaver::xdgProcess_finished(int err, QProcess::ExitStatus status)

--- a/razorqt-resources/autostart/razor-xscreensaver-autostart.desktop
+++ b/razorqt-resources/autostart/razor-xscreensaver-autostart.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=XScreenSaver
+TryExec=xscreensaver
+Exec=xscreensaver
+OnlyShowIn=RAZOR;


### PR DESCRIPTION
Currently, when clicking "Lock Screen", it executes "xdg-screensaver activate", which just turns off the screen. If XScreenSaver is running, it activates it, but the screen is not locked.

According to `man xdg-screensaver`, that just activates the screensaver. To really lock the screen, xdg-screensaver lock" needs to be run instead:

```
   activate
       Turns the screensaver on immediately. This may result in the screen
       getting locked, depending on existing system policies.

   lock
       Lock the screen immediately.
```

However, if xscreensaver is not running, it obviously can't lock the screen, so I added xscreensaver to autostart, when it's available.

Of course, now it will give an error if the user attempts to lock the screen without it running (instead of just turning it off like it does now), but I think this is more correct.
