### PR TITLE
Notepad save method fixed

### DIFF
--- a/razorqt-desktop/desktop-razor/plugin-notepad/notepadwin.cpp
+++ b/razorqt-desktop/desktop-razor/plugin-notepad/notepadwin.cpp
@@ -362,9 +362,3 @@ void NotepadWin::onSelectionChanged()
     rightSided->setChecked(aRight ? true : false);
     justified->setChecked(aJustify ? true : false);
 }
-
-void NotepadWin::paintEvent(QPaintEvent *event)
-{
-	(pad->*saveText)();
-	QWidget::paintEvent(event);
-}

--- a/razorqt-desktop/desktop-razor/plugin-notepad/notepadwin.h
+++ b/razorqt-desktop/desktop-razor/plugin-notepad/notepadwin.h
@@ -57,21 +57,18 @@ public:
 	QString text();
 	void setText(QString &text);
 
-protected:
-	void paintEvent(QPaintEvent *event);
-
 private slots:
 	void textChanged();
 public slots:
-        void onSelectionChanged();
-        void setBold();
-        void setItalic();
-        void setUnderline();
-        void setStrike();
-        void setLeftSided();
-        void setCentered();
-        void setRightSided();
-        void setJustified();
+    void onSelectionChanged();
+    void setBold();
+    void setItalic();
+    void setUnderline();
+    void setStrike();
+    void setLeftSided();
+    void setCentered();
+    void setRightSided();
+    void setJustified();
 };
 
 #endif


### PR DESCRIPTION
NotepadWin::paintEvent(QPaintEvent *) implementation (with a save function) has been removed from class, because it isn't necessary.
