### PR TITLE
Make bundling xdg-tools optional

### DIFF
--- a/razorqt-session/CMakeLists.txt
+++ b/razorqt-session/CMakeLists.txt
@@ -51,8 +51,19 @@ add_dependencies( razor-session razorqt qtxdg)
 target_link_libraries ( razor-session  ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTDBUS_LIBRARY} ${QT_QTXML_LIBRARY} ${X11_X11_LIB} razorqt qtxdg)
 INSTALL(TARGETS razor-session RUNTIME DESTINATION bin)
 
-install(PROGRAMS resources/xdg-open resources/xdg-mime DESTINATION lib${LIB_SUFFIX}/razor-xdg-tools)
-add_definitions ( -DPATH_PREPEND=\"${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/razor-xdg-tools\" )
+if (NOT DEFINED BUNDLE_XDG_UTILS)
+    message(STATUS "*********************************************************************")
+    message(STATUS "Bundling our own xdg-utils.")
+    message(STATUS "If you have xdg-utils newer than 2012-03-02, you can set -DBUNDLE_XDG_UTILS=No")
+    message(STATUS "*********************************************************************")
+    set (BUNDLE_XDG_UTILS Yes)
+endif (NOT DEFINED BUNDLE_XDG_UTILS)
+
+if (BUNDLE_XDG_UTILS)
+    install(PROGRAMS resources/xdg-open resources/xdg-mime DESTINATION lib${LIB_SUFFIX}/razor-xdg-tools)
+    add_definitions ( -DPATH_PREPEND=\"${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/razor-xdg-tools\" )
+endif (BUNDLE_XDG_UTILS)
+
 install(PROGRAMS src/startrazor DESTINATION bin)
 
 add_subdirectory(config)

--- a/razorqt-session/src/main.cpp
+++ b/razorqt-session/src/main.cpp
@@ -73,8 +73,11 @@ int main(int argc, char **argv)
         }
     }
     
+#ifdef PATH_PREPEND
     // PATH for out own bundled XDG tools
     razor_setenv_prepend("PATH", PATH_PREPEND);
+#endif // PATH_PREPEND
+
     // special variable for Razor environment menu
     razor_setenv("XDG_MENU_PREFIX", "razor-");
 


### PR DESCRIPTION
Now that the patches to xdg-open and xdg-mime were merged, it would make sense to make using our bundled versions optional - Gentoo, for instance, updated to the latest snapshot of xdg-utils today.

Please check if I'm doing it correctly (I don't know CMake well.)
