### PR TITLE
Fixes xscreensaver non existent --no-splash option

### DIFF
--- a/razorqt-resources/autostart/razor-xscreensaver-autostart.desktop.in
+++ b/razorqt-resources/autostart/razor-xscreensaver-autostart.desktop.in
@@ -3,7 +3,7 @@ Type=Application
 Version=1.0
 Name=XScreenSaver
 TryExec=xscreensaver
-Exec=xscreensaver --no-splash
+Exec=xscreensaver -no-splash
 OnlyShowIn=Razor;
 
 #TRANSLATIONS_DIR=translations


### PR DESCRIPTION
Fixes commit d636f87b02efaec81042388ec8bb8c41eb74bdac (fixed #271 XDG
autostart Xscreensaver must added missing "--no-splash")
XScreenSaver Manual: http://www.jwz.org/xscreensaver/man1.html

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
