### PR TITLE
Use shorter names in Razor Configuration Center > Razor-qt settings

### DIFF
--- a/razorqt-config/razor-config-appearance/razor-config-appearance.desktop.in
+++ b/razorqt-config/razor-config-appearance/razor-config-appearance.desktop.in
@@ -6,8 +6,8 @@ Exec=razor-config-appearance
 Terminal=false
 Categories=Settings;DesktopSettings;Qt;X-RAZOR;
 Icon=preferences-desktop-theme
-Name=Razor Appearance Configuration
+Name=Appearance
 Comment=Configure appearance of Razor desktop
-GenericName=Razor Appearance Configuration
+GenericName=Appearance
 
 #TRANSLATIONS_DIR=translations

--- a/razorqt-config/razor-config-mouse/razor-config-mouse.desktop.in
+++ b/razorqt-config/razor-config-mouse/razor-config-mouse.desktop.in
@@ -6,8 +6,8 @@ Exec=razor-config-mouse
 Terminal=false
 Categories=Settings;DesktopSettings;Qt;X-RAZOR;
 Icon=preferences-desktop-mouse
-Name=Razor Mouse Configurator
+Name=Mouse
 Comment=Configure X11 mouse
-GenericName=Razor Mouse Configurator
+GenericName=Mouse
 
 #TRANSLATIONS_DIR=translations

--- a/razorqt-config/razor-config-notificationd/razor-config-notificationd.desktop.in
+++ b/razorqt-config/razor-config-notificationd/razor-config-notificationd.desktop.in
@@ -6,7 +6,7 @@ Exec=razor-config-notificationd
 Terminal=false
 Categories=Settings;DesktopSettings;Qt;X-RAZOR;
 Icon=preferences-desktop-theme
-Name=Razor Freedesktop Notifications Configuration
+Name=Notifications
 Comment=Configure freedesktop notifications in Razor desktop
 GenericName=Razor Freedesktop Notifications Configuration
 

--- a/razorqt-desktop/config/razor-config-desktop.desktop.in
+++ b/razorqt-desktop/config/razor-config-desktop.desktop.in
@@ -5,8 +5,8 @@ Exec=razor-config-desktop
 Terminal=false
 Categories=Settings;DesktopSettings;Qt;X-RAZOR;
 Icon=preferences-desktop
-Name=Razor Desktop Configurator
+Name=Desktop
 Comment=Configure Razor-Qt desktop module
-GenericName=Razor Desktop Configurator
+GenericName=Desktop
 
 #TRANSLATIONS_DIR=translations

--- a/razorqt-session/config/razor-config-session.desktop.in
+++ b/razorqt-session/config/razor-config-session.desktop.in
@@ -5,8 +5,8 @@ Exec=razor-config-session
 Terminal=false
 Categories=Settings;DesktopSettings;Qt;X-RAZOR;
 Icon=preferences-system-session-services
-Name=Razor Session Configurator
+Name=Session
 Comment=Configure Razor-Qt session module
-GenericName=Razor Session Configurator
+GenericName=Session
 
 #TRANSLATIONS_DIR=translations


### PR DESCRIPTION
With the categorized view there is no chance of confusion between Razor
configuration and other configurations.
It results in a cleaner interface.

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
