### PR TITLE
Change enter key handling in Greeter

### DIFF
--- a/razorqt-lightdm-greeter/loginform.cpp
+++ b/razorqt-lightdm-greeter/loginform.cpp
@@ -95,7 +95,6 @@ LoginForm::LoginForm(QWidget *parent) : QWidget(parent), ui(new Ui::LoginForm)
             this,       SLOT(onPrompt(QString,QLightDM::Greeter::PromptType)));
 #endif
 
-    connect(ui->loginButton, SIGNAL(pressed()), this, SLOT(doLogin()));
     connect(ui->loginButton, SIGNAL(clicked(bool)), this, SLOT(doLogin()));
 
     connect(ui->cancelButton, SIGNAL(clicked()), SLOT(doCancel()));
@@ -162,12 +161,4 @@ void LoginForm::doLeave()
 
 void LoginForm::razorPowerDone() {
     setEnabled(true);
-}
-
-void LoginForm::keyPressEvent(QKeyEvent *event)
-{
-    if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return)
-    {
-        emit ui->loginButton->click();
-    }
 }

--- a/razorqt-lightdm-greeter/loginform.h
+++ b/razorqt-lightdm-greeter/loginform.h
@@ -64,9 +64,6 @@ public slots:
 #endif
     void authenticationDone();
 
-protected:
-    virtual void keyPressEvent(QKeyEvent *event);
-
 private:
     Ui::LoginForm *ui;
 

--- a/razorqt-lightdm-greeter/loginform.ui
+++ b/razorqt-lightdm-greeter/loginform.ui
@@ -75,7 +75,7 @@
     <bool>false</bool>
    </property>
    <property name="placeholderText">
-    <string>userid</string>
+    <string>user id</string>
    </property>
   </widget>
   <widget class="QLineEdit" name="passwordInput">
@@ -226,5 +226,38 @@
   </widget>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>userIdInput</sender>
+   <signal>returnPressed()</signal>
+   <receiver>passwordInput</receiver>
+   <slot>setFocus()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>513</x>
+     <y>95</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>513</x>
+     <y>145</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>passwordInput</sender>
+   <signal>returnPressed()</signal>
+   <receiver>loginButton</receiver>
+   <slot>animateClick()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>419</x>
+     <y>130</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>389</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
Hi Christian,

I've been experiencing random crashes with lightdm if I hit Enter. It seems to be due to it trying to call authenticate() twice in a row. This commit seem so fix it.

I changed the Enter key behavior slightly - it now triggers login only if you're focused on the password field, which I think makes the most sense.

If it looks good, please merge.
