### PR TITLE
razor-panel: Setup Configure Panel>Panel size Ui properly

### DIFF
--- a/razorqt-panel/panel/configpaneldialog.cpp
+++ b/razorqt-panel/panel/configpaneldialog.cpp
@@ -104,7 +104,9 @@ void ConfigPanelDialog::reset()
             ui->comboBox_position->setCurrentIndex(ix);
     }
 
-    emit configChanged(mSize, mLength, mWidthInPercents, mAlignment, mUseThemeSize);
+    // checkBoxUseThemeSizeChanged emits the configChanged signal
+    // if mUseThemeSize is true it disables the size spinbox
+    checkBoxUseThemeSizeChanged(mUseThemeSize);
     emit positionChanged(mScreenNum, mPosition);
 }
 


### PR DESCRIPTION
When setting up the Configure Panel Ui if the 'Use Theme size' checkbox is
marked the Size spinbox must be disabled.

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
