### PR TITLE
qt4 4.6 compatibility issues : breacks notification plugin and mount app plugin

### DIFF
--- a/razorqt-panel/plugin-mount/mountbutton.cpp
+++ b/razorqt-panel/plugin-mount/mountbutton.cpp
@@ -181,7 +181,8 @@ void MountButton::showMessage(const QString &text)
     RazorNotification::notify(toolTip(), text,
 #if QT_VERSION >= 0x040700
                               icon().name()
-#endif
+#else
+                              "application-x-cd-image"#endif
                               );
 }
 


### PR DESCRIPTION
...4.6 detected,

the funtion member fails due missing argument. please implement qt 4.6 compatible api.. 

some cases need here: 
*acer eee-pc can install a large qt4 environment (qt 4.7 takes 600Mb vs 4.6 that need 400Mb, i mean complete framework) 
*debian squeee and venenux 0.8 still use qt4 4.6.3 as qt4 api ...
*some light distribution need a lower version even a newer version of qt4 api, such dsl, slitaz, etc 

https://groups.google.com/group/razor-qt/browse_thread/thread/36cec5da83ff6291

NOTE:theres no fun in a light desktop if not install in a older environment/distributions<<<<<<
