### PR TITLE
the converFromImage saves ram memory event fromImage that only copies, b...

### DIFF
--- a/razorqt-notificationd/src/notification.cpp
+++ b/razorqt-notificationd/src/notification.cpp
@@ -192,7 +192,7 @@ QPixmap Notification::getPixmapFromHint(const QVariant &argument) const
     arg.endStructure();
     QImage img = QImage((uchar*)data.constData(), width, height, QImage::Format_ARGB32).rgbSwapped();
 
-    p.convertFromImage(img);
+    p.convertImage(img); // see https://groups.google.com/group/razor-qt/browse_thread/thread/36cec5da83ff6291
     return p;
 }
 


### PR DESCRIPTION
...ut

the previos was not found in api version since qt4 4.7.0, was introduced 
aftyer large discutions and breaks compilation in older distributions... 
some cases need here: 
*acer eee-pc can install a large qt4 environment (qt 4.7 takes 600Mb vs 4.6 
that need 400Mb, i mean complete framework) 
*debian squeee and venenux 0.8 still use qt4 4.6.3 as qt4 api ... 
*some light distribution need a lower version even a newer version of qt4 
api, such dsl, slitaz, etc 

Please see https://groups.google.com/group/razor-qt/browse_thread/thread/36cec5da83ff6291
