### PR TITLE
debian/control: necesary depends: Added libsensors4-dev for new lm_sensor plugin on razor-panel, all the r...

### DIFF
--- a/distr/deb/debian/control
+++ b/distr/deb/debian/control
@@ -17,7 +17,8 @@ Build-Depends: debhelper (>= 7.0.50~), pkg-config,
     libpolkit-qt-1-dev,
 %endif
     zlib1g-dev,
-    libstatgrab-dev
+    libstatgrab-dev,
+    libsensors4-dev
 Standards-Version: 3.9.1
 Homepage: http://razor-qt.org
 


### PR DESCRIPTION
Added libsensors4-dev for new lm_sensor plugin on razor-panel, all the rest not affected by recent commits..

Wiki was updated too https://github.com/Razor-qt/razor-qt/wiki/Dependencies see coment in wiki history.. 

new plugin need libsensors4-dev for build, theres no changes need in razor-panel.install file.. all pass sucessfully
