### PR TITLE
working dh_install command updating librazorqt0.install acordin to https://github.com/Razor-qt/razor-qt/pull/294

### DIFF
--- a/distr/deb/debian/librazorqt0.install
+++ b/distr/deb/debian/librazorqt0.install
@@ -1,5 +1,4 @@
 /usr/lib*/librazormount.so.*
 /usr/lib*/librazorqt.so.*
 /usr/lib*/librazorqxt.so.*
-/usr/lib*/libqtservice.so.*
 /usr/share/librazorqt/


### PR DESCRIPTION
removed libqtservice acordin to https://github.com/Razor-qt/razor-qt/pull/294 now closed, this its necesary for debian working dh_install command..
