### PR TITLE
razor-panel: Adds mount to the default plugin list

### DIFF
--- a/razorqt-panel/panel/resources/panel.conf
+++ b/razorqt-panel/panel/resources/panel.conf
@@ -1,5 +1,5 @@
 [panel]
-plugins=mainmenu,desktopswitch,quicklaunch,taskbar,tray,clock
+plugins=mainmenu,desktopswitch,quicklaunch,taskbar,tray,mount,clock
 position=Bottom
 desktop=0
 
@@ -22,6 +22,9 @@ type=taskbar
 
 [tray]
 type=tray
+
+[mount]
+type=mount
 
 [clock]
 type=clock


### PR DESCRIPTION
The user expects that in a modern desktop environment something happens
when a removable device is plugged in. The mount plugin should be part of
the default configuration.

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
