### PR TITLE
razorqt-notificationd: Fix the placement restore configuration Ui

### DIFF
--- a/razorqt-notificationd/config/basicsettings.cpp
+++ b/razorqt-notificationd/config/basicsettings.cpp
@@ -55,11 +55,11 @@ void BasicSettings::restoreSettings()
     QString placement = mSettings->value("placement", "bottom-right").toString().toLower();
     if (placement == "bottom-right")
         bottomRightButton->setChecked(true);
-    if (placement == "bottom-left")
+    else if (placement == "bottom-left")
         bottomLeftButton->setChecked(true);
-    if (placement == "top-right")
+    else if (placement == "top-right")
         topRightButton->setChecked(true);
-    if (placement == "top-left")
+    else if (placement == "top-left")
         topLeftButton->setChecked(true);
     else
         bottomRightButton->setChecked(true);


### PR DESCRIPTION
The placement settings weren't being properly loaded to the config Ui. In
some cases it improperly defaulted to bottom-right.

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
