### PR TITLE
[297] Sensors panel plugin - blink progress bar when the temperature is too high

### DIFF
--- a/razorqt-panel/plugin-sensors/razorsensors.h
+++ b/razorqt-panel/plugin-sensors/razorsensors.h
@@ -33,6 +33,7 @@
 #include <QtCore/QTimer>
 #include <QtGui/QProgressBar>
 #include <sensors/sensors.h>
+#include <set>
 
 class RazorSensors : public RazorPanelPlugin
 {
@@ -45,6 +46,7 @@ public:
 
 public slots:
     void updateSensorReadings();
+    void warningAboutHighTemperature();
 
 private slots:
     virtual void showConfigureDialog();
@@ -52,10 +54,15 @@ private slots:
     virtual void realign();
 
 private:
-    QTimer *mUpdateSensorReadingsTimer;
+    QTimer mUpdateSensorReadingsTimer;
+    QTimer mWarningAboutHighTemperatureTimer;
+    // How often warning time should fire in ms
+    int mWarningAboutHighTemperatureTimerFreq;
     Sensors mSensors;
     std::vector<Chip> mDetectedChips;
     std::vector<QProgressBar*> mTemperatureProgressBars;
+    // With set we can handle updates in very easy way :)
+    std::set<QProgressBar*> mHighTemperatureProgressBars;
     double celsiusToFahrenheit(double celsius);
     void initDefaultSettings();
 };

--- a/razorqt-panel/plugin-sensors/razorsensorsconfiguration.cpp
+++ b/razorqt-panel/plugin-sensors/razorsensorsconfiguration.cpp
@@ -54,6 +54,7 @@ RazorSensorsConfiguration::RazorSensorsConfiguration(QSettings &settings, QWidge
     connect(ui->celsiusTempScaleRB, SIGNAL(toggled(bool)), this, SLOT(saveSettings()));
     // We don't need signal from the other radio box as celsiusTempScaleRB will send one
     //connect(ui->fahrenheitTempScaleRB, SIGNAL(toggled(bool)), this, SLOT(saveSettings()));
+    connect(ui->warningAboutHighTemperatureChB, SIGNAL(toggled(bool)), this, SLOT(saveSettings()));
 
     /**
      * Signals for enable/disable and bar color change are set in the loadSettings method because
@@ -93,6 +94,9 @@ void RazorSensorsConfiguration::loadSettings()
     {
         detectedChipSelected(0);
     }
+
+    ui->warningAboutHighTemperatureChB->setChecked(
+            mSettings.value("warningAboutHighTemperature").toBool());
 }
 
 void RazorSensorsConfiguration::saveSettings()
@@ -141,6 +145,9 @@ void RazorSensorsConfiguration::saveSettings()
 
     }
     mSettings.endGroup();
+
+    mSettings.setValue("warningAboutHighTemperature",
+                       ui->warningAboutHighTemperatureChB->isChecked());
 }
 
 void RazorSensorsConfiguration::dialogButtonsAction(QAbstractButton *btn)

--- a/razorqt-panel/plugin-sensors/razorsensorsconfiguration.ui
+++ b/razorqt-panel/plugin-sensors/razorsensorsconfiguration.ui
@@ -85,6 +85,19 @@
          </property>
         </widget>
        </item>
+       <item row="5" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
        <item row="3" column="0" colspan="2">
         <widget class="QGroupBox" name="tempScaleGB">
          <property name="title">
@@ -113,18 +126,24 @@
          <zorder>celsiusTempScaleRB</zorder>
         </widget>
        </item>
-       <item row="4" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+       <item row="2" column="0" colspan="2">
+        <widget class="QCheckBox" name="warningAboutHighTemperatureChB">
+         <property name="toolTip">
+          <string>Blink progress bars when the temperature is too high</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
          </property>
-        </spacer>
+         <property name="text">
+          <string>Warning about high temperature</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <property name="tristate">
+          <bool>false</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
All done, when the temperature is too high then current temperature text in the tooltip has red color and appropriate progress bar is "blinking" from minimum to maximum to indicate that something bad is going on :) (To test it You can simply hack it in the code:  "if (curTemp >= maxTemp)" ;))
