### PR TITLE
Add the "TryExec" key

### DIFF
--- a/razorqt-resources/sys/razor.desktop.in
+++ b/razorqt-resources/sys/razor.desktop.in
@@ -2,6 +2,7 @@
 Encoding=UTF-8
 Type=XSession
 Exec=razor-session
+TryExec=razor-session
 Name=Razor Desktop
 Comment=Qt4 Desktop
 


### PR DESCRIPTION
On my system, razor.desktop is the only one which does not contain the "TryExec" key among those .desktop files under /usr/share/apps/kdm/sessions/ and /usr/share/xsessions/ 

Also see http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html
