### PR TITLE
Only show razor-autosuspend in the menu when using the razor environment

### DIFF
--- a/razorqt-power/razor-autosuspend/resources/razor-autosuspend.desktop.in
+++ b/razorqt-power/razor-autosuspend/resources/razor-autosuspend.desktop.in
@@ -3,6 +3,7 @@ Type=Application
 Exec=razor-autosuspend
 Icon=razor-autosuspend
 Terminal=false
+OnlyShowIn=X-RAZOR;
 Categories=Qt;Utility;
 Name=Razor autosuspend
 GenericName=Power management


### PR DESCRIPTION
Among those razor*.desktop files under /usr/share/applications, only razor-autosuspend.deksotp does not contain the "OnlyShowIn" key. Is that a omission or intentional exception? I personally do not see why razor-autosuspend should be the exception, since its functionality is likely to interfere with the native power management  of the DE.
