### PR TITLE
razor-panel: Read the panel size value when not using the theme size

### DIFF
--- a/razorqt-panel/panel/configpaneldialog.cpp
+++ b/razorqt-panel/panel/configpaneldialog.cpp
@@ -200,6 +200,10 @@ void ConfigPanelDialog::checkBoxUseThemeSizeChanged(bool state)
         ui->label_size->setEnabled(true);
         ui->spinBox_size->setEnabled(true);
         ui->label_px->setEnabled(true);
+
+        // If the useTheme checkbox is unchecked, the size spinbox value
+        // should be retrieved
+        mSize = ui->spinBox_size->value();
     }
 
     emit configChanged(mSize, mLength, mWidthInPercents, mAlignment, mUseThemeSize);


### PR DESCRIPTION
When not using the theme size the size spinbox wasn't take into account.
mSize defaults to -1 which made the panel almost disappear completely.

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
