### PR TITLE
razor-panel: Replace 'Delete' by 'Remove'. Closes #339

### DIFF
--- a/razorqt-panel/panel/razorpanelplugin.cpp
+++ b/razorqt-panel/panel/razorpanelplugin.cpp
@@ -143,7 +143,7 @@ QMenu* RazorPanelPlugin::popupMenu() const
 
     menu->addSeparator();
 
-    QAction* removeAction = new QAction(XdgIcon::fromTheme("dialog-close"), tr("Delete"), menu);
+    QAction* removeAction = new QAction(XdgIcon::fromTheme("dialog-close"), tr("Remove"), menu);
     menu->addAction(removeAction);
     connect(removeAction, SIGNAL(triggered()), this, SLOT(requestRemove()));
 


### PR DESCRIPTION
Replaces 'Delete' by 'Remove' ate the RazorPanelPlugin popupmenu.
'Remove' is more accurate than 'Delete'. And more intuitive: What the user
wants is to remove a plugin from the panel.

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
