### PR TITLE
The QT 4.7 API for some reason, docs doesn't specify the msecsTo as new...

### DIFF
--- a/razorqt-notificationd/src/notification.cpp
+++ b/razorqt-notificationd/src/notification.cpp
@@ -299,7 +299,15 @@ void NotificationTimer::pause()
         return;
 
     stop();
-    m_intervalMsec = m_startTime.time().msecsTo(QDateTime::currentDateTime().time());
+#if QT_VERSION >= 0x040700
+    m_intervalMsec = m_startTime.msecsTo(QDateTime());
+#else
+    QDate currentDate = QDate::currentDate();
+    QTime currentTime = QTime::currentTime();
+    qint64 MSECS_PER_DAY = 86400000;
+    m_intervalMsec = static_cast<qint64>(m_startTime.date().daysTo(currentDate)) * MSECS_PER_DAY
+               + static_cast<qint64>(m_startTime.time().msecsTo(currentTime));
+#endif
 }
 
 void NotificationTimer::resume()


### PR DESCRIPTION
The QT 4.7 API for some reason, docs doesn't specify the msecsTo as new so fixed using QTime equivalent in QDateTime:

the msecsTo are since qt4 4.7 and not work with qt 4.6.X previous commit must be reverted!! i undesrtand u stablies the duration of notification comparing the milisecons since notification shows? 

a possible solution could be using Qtime class event QdateTime as http://cep.xor.aps.anl.gov/software/qt4-x11-4.2.2-browser/df/dc6/class_q_time.html#899f6a5ccad59578249c7717ce5dfcb5 i paste a possible code here an prpopost the request of pull as follow:

Line 291 aprox
m_statTime = QDateTime::currentDateTime();  

Line 302 aprox
m_intervalMsec = m_startTime.time().msecsTo(QDateTime::currentDateTime().time());

.. this its using Qtime class that are not so precise like QDate time but for a message a seconds are enought.. so

THERS NO FUN IN A LIGHT DESKTOP THAT ITS NO LIGHT IN REQUERIMENTS JE JE
