### PR TITLE
CpuLoad plugin - color bar has configurable orientation

### DIFF
--- a/razorqt-panel/plugin-cpuload/razorcpuload.cpp
+++ b/razorqt-panel/plugin-cpuload/razorcpuload.cpp
@@ -35,12 +35,17 @@ extern "C" {
 #include <statgrab.h>
 }
 
+#define BAR_ORIENT_BOTTOMUP "bottomUp"
+#define BAR_ORIENT_TOPDOWN "topDown"
+#define BAR_ORIENT_LEFTRIGHT "leftRight"
+#define BAR_ORIENT_RIGHTLEFT "rightLeft"
 
 EXPORT_RAZOR_PANEL_PLUGIN_CPP(RazorCpuLoad)
 
 RazorCpuLoad::RazorCpuLoad(const RazorPanelPluginStartInfo* startInfo, QWidget* parent):
 	RazorPanelPlugin(startInfo, parent),
 	m_showText(false),
+    m_barOrientation(TopDownBar),
     m_timerID(-1)
 {
 	setObjectName("CpuLoad");
@@ -65,9 +70,18 @@ RazorCpuLoad::~RazorCpuLoad()
 
 void RazorCpuLoad::resizeEvent(QResizeEvent *)
 {
-	m_stuff.setMinimumWidth(18);
-	m_stuff.setMaximumWidth(18);
-	m_stuff.setMinimumHeight(24);
+    if (m_barOrientation == RightToLeftBar || m_barOrientation == LeftToRightBar)
+    {
+        m_stuff.setMinimumHeight(18);
+        m_stuff.setMaximumHeight(18);
+        m_stuff.setMinimumWidth(24);
+    }
+    else
+    {
+        m_stuff.setMinimumWidth(18);
+        m_stuff.setMaximumWidth(18);
+        m_stuff.setMinimumHeight(24);
+    }
 
 	update();
 }
@@ -102,16 +116,43 @@ void RazorCpuLoad::paintEvent ( QPaintEvent * )
 	p.setFont(m_font);
 	QRectF r = rect();
 
-	float vo = r.height()*(1-m_avg*0.01);
-	float ho = (r.width() - w )/2.0;
-	QRectF r1(r.left()+ho, r.top()+vo, r.width()-2*ho, r.height()-vo );
+    QRectF r1;
+    QLinearGradient shade(0,0,1,1);
+    if (m_barOrientation == RightToLeftBar || m_barOrientation == LeftToRightBar)
+    {
+        float vo = (r.height() - w )/2.0;
+        float ho = r.width()*(1-m_avg*0.01);
 
-	QLinearGradient shade(0, 0, r1.width(), 0);
+        if (m_barOrientation == RightToLeftBar)
+        {
+            r1.setRect(r.left()+ho, r.top()+vo, r.width()-ho, r.height()-2*vo );
+        }
+        else // LeftToRightBar
+        {
+            r1.setRect(r.left(), r.top()+vo, r.width()-ho, r.height()-2*vo );
+        }
+        shade.setFinalStop(0, r1.height());
+    }
+    else // BottomUpBar || TopDownBar
+    {
+        float vo = r.height()*(1-m_avg*0.01);
+        float ho = (r.width() - w )/2.0;
+
+        if (m_barOrientation == TopDownBar)
+        {
+            r1.setRect(r.left()+ho, r.top(), r.width()-2*ho, r.height()-vo );
+        }
+        else // BottomUpBar
+        {
+            r1.setRect(r.left()+ho, r.top()+vo, r.width()-2*ho, r.height()-vo );
+        }
+        shade.setFinalStop(r1.width(), 0);
+    }
+
 	shade.setSpread(QLinearGradient::ReflectSpread);
 	shade.setColorAt(0, QColor(0, 196, 0, 128));
 	shade.setColorAt(0.5, QColor(0, 128, 0, 255) );
 	shade.setColorAt(1, QColor(0, 196, 0 , 128));
-
 
 	p.fillRect(r1, shade);
 
@@ -141,6 +182,16 @@ void RazorCpuLoad::settingsChanged()
 
 	m_showText = settings().value("showText", false).toBool();
     m_updateInterval = settings().value("updateInterval", 1000).toInt();
+
+    QString barOrientation = settings().value("barOrientation", BAR_ORIENT_BOTTOMUP).toString();
+    if (barOrientation == BAR_ORIENT_RIGHTLEFT)
+        m_barOrientation = RightToLeftBar;
+    else if (barOrientation == BAR_ORIENT_LEFTRIGHT)
+        m_barOrientation = LeftToRightBar;
+    else if (barOrientation == BAR_ORIENT_TOPDOWN)
+        m_barOrientation = TopDownBar;
+    else
+        m_barOrientation = BottomUpBar;
 
 	m_timerID = startTimer(m_updateInterval);
 	update();

--- a/razorqt-panel/plugin-cpuload/razorcpuload.h
+++ b/razorqt-panel/plugin-cpuload/razorcpuload.h
@@ -34,6 +34,16 @@ class RazorCpuLoad: public RazorPanelPlugin
 {
 	Q_OBJECT
 public:
+    /**
+      Describes orientation of cpu load bar
+     **/
+    enum BarOrientation {
+        BottomUpBar,    //! Bar begins at bottom and grows up
+        TopDownBar,     //! Bar begins at top and grows down
+        RightToLeftBar, //! Bar begins at right edge and grows to the left
+        LeftToRightBar  //! Bar begins at left edge and grows to the right
+    };
+
 	RazorCpuLoad(const RazorPanelPluginStartInfo* startInfo, QWidget* parent = 0);
 	~RazorCpuLoad();
 
@@ -57,6 +67,7 @@ private:
 	int m_avg;
 
 	bool m_showText;
+    BarOrientation m_barOrientation;
     int m_updateInterval;
     int m_timerID;
 

--- a/razorqt-panel/plugin-cpuload/razorcpuloadconfiguration.cpp
+++ b/razorqt-panel/plugin-cpuload/razorcpuloadconfiguration.cpp
@@ -25,9 +25,13 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-
 #include "razorcpuloadconfiguration.h"
 #include "ui_razorcpuloadconfiguration.h"
+
+#define BAR_ORIENT_BOTTOMUP "bottomUp"
+#define BAR_ORIENT_TOPDOWN "topDown"
+#define BAR_ORIENT_LEFTRIGHT "leftRight"
+#define BAR_ORIENT_RIGHTLEFT "rightLeft"
 
 RazorCpuLoadConfiguration::RazorCpuLoadConfiguration(QSettings &settings, QWidget *parent) :
 	QDialog(parent),
@@ -39,6 +43,8 @@ RazorCpuLoadConfiguration::RazorCpuLoadConfiguration(QSettings &settings, QWidge
 	setObjectName("CpuLoadConfigurationWindow");
 	ui->setupUi(this);
 
+    fillBarOrientations();
+
 	connect(ui->buttons, SIGNAL(clicked(QAbstractButton*)),
             this, SLOT(dialogButtonsAction(QAbstractButton*)));
 
@@ -48,6 +54,8 @@ RazorCpuLoadConfiguration::RazorCpuLoadConfiguration(QSettings &settings, QWidge
             this, SLOT(showTextChanged(bool)));
     connect(ui->updateIntervalSpinBox, SIGNAL(valueChanged(double)),
             this, SLOT(updateIntervalChanged(double)));
+    connect(ui->barOrientationCOB, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(barOrientationChanged(int)));
 }
 
 RazorCpuLoadConfiguration::~RazorCpuLoadConfiguration()
@@ -55,10 +63,23 @@ RazorCpuLoadConfiguration::~RazorCpuLoadConfiguration()
 	delete ui;
 }
 
+void RazorCpuLoadConfiguration::fillBarOrientations()
+{
+    ui->barOrientationCOB->addItem(trUtf8("Bottom up"), BAR_ORIENT_BOTTOMUP);
+    ui->barOrientationCOB->addItem(trUtf8("Top down"), BAR_ORIENT_TOPDOWN);
+    ui->barOrientationCOB->addItem(trUtf8("Left to right"), BAR_ORIENT_LEFTRIGHT);
+    ui->barOrientationCOB->addItem(trUtf8("Right to left"), BAR_ORIENT_RIGHTLEFT);
+}
+
 void RazorCpuLoadConfiguration::loadSettings()
 {
 	ui->showTextCB->setChecked(mSettings.value("showText", false).toBool());
     ui->updateIntervalSpinBox->setValue(mSettings.value("updateInterval", 1000).toInt() / 1000.0);
+
+    int boIndex = ui->barOrientationCOB->findData(
+            mSettings.value("barOrientation", BAR_ORIENT_BOTTOMUP));
+    boIndex = (boIndex < 0) ? 1 : boIndex;
+    ui->barOrientationCOB->setCurrentIndex(boIndex);
 
 //	QString menuFile = mSettings.value("menu_file", "").toString();
 //	if (menuFile.isEmpty())
@@ -80,6 +101,10 @@ void RazorCpuLoadConfiguration::updateIntervalChanged(double value)
 	mSettings.setValue("updateInterval", value*1000);
 }
 
+void RazorCpuLoadConfiguration::barOrientationChanged(int index)
+{
+    mSettings.setValue("barOrientation", ui->barOrientationCOB->itemData(index).toString());
+}
 
 void RazorCpuLoadConfiguration::dialogButtonsAction(QAbstractButton *btn)
 {

--- a/razorqt-panel/plugin-cpuload/razorcpuloadconfiguration.h
+++ b/razorqt-panel/plugin-cpuload/razorcpuloadconfiguration.h
@@ -53,6 +53,11 @@ private:
 	QSettings &mSettings;
 	RazorSettingsCache mOldSettings;
 
+    /*
+      Fills Bar orientation combobox
+    */
+    void fillBarOrientations();
+
 private slots:
 	/*
 	  Saves settings in conf file.
@@ -61,6 +66,7 @@ private slots:
 	void dialogButtonsAction(QAbstractButton *btn);
 	void showTextChanged(bool value);
     void updateIntervalChanged(double value);
+    void barOrientationChanged(int index);
 
 };
 

--- a/razorqt-panel/plugin-cpuload/razorcpuloadconfiguration.ui
+++ b/razorqt-panel/plugin-cpuload/razorcpuloadconfiguration.ui
@@ -65,6 +65,16 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="barOrientationL">
+        <property name="text">
+         <string>Bar orientation:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="barOrientationCOB"/>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Small feature - adds option to choose bar orientation of CPULoad panel-plugin.
Handy for situations, where Panel is placed at another edge of the screen (not the bottom as by default).
