### PR TITLE
razoor-panel: Adds Orientation property

### DIFF
--- a/razorqt-panel/panel/razorpanel.cpp
+++ b/razorqt-panel/panel/razorpanel.cpp
@@ -697,6 +697,19 @@ RazorPanel::Position RazorPanel::position() const
     return d->position();
 }
 
+RazorPanel::Orientation RazorPanel::orientation() const
+{
+    Q_D(const RazorPanel);
+    if (d->mPosition == RazorPanel::PositionBottom ||
+        d->mPosition == RazorPanel::PositionTop)
+    {
+        return RazorPanel::Horizontal;
+    }
+    else
+    {
+        return RazorPanel::Vertical;
+    }
+}
 
 /************************************************
 

--- a/razorqt-panel/panel/razorpanel.h
+++ b/razorqt-panel/panel/razorpanel.h
@@ -43,7 +43,9 @@ class RazorPanel : public QFrame
 {
     Q_OBJECT
     Q_PROPERTY(Position position READ position NOTIFY positionChanged)
+    Q_PROPERTY(Orientation orientation READ orientation)
     Q_ENUMS(Position)
+    Q_ENUMS(Orientation)
     friend class RazorPanelPlugin;
 
 public:
@@ -60,11 +62,17 @@ public:
         AlignmentRight  =  1
     };
 
+    enum Orientation {
+        Horizontal,
+        Vertical
+    };
+
     RazorPanel(QWidget *parent = 0);
     virtual ~RazorPanel();
 
     Position position() const ;
     bool isHorizontal() const { return position() == PositionBottom || position() == PositionTop; }
+    Orientation orientation() const;
 
     void showPopupMenu(RazorPanelPlugin *plugin = 0);
     void x11EventFilter(XEvent* event);


### PR DESCRIPTION
It can be useful for theme authors. Example:

/\* Horizontal panel */
RazorPanel[orientation="0"] {
    */ define some properties */
}

/\* Vertical panel */
RazorPanel[orientation="1"] {
    */ define some properties */
}

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
