### PR TITLE
razor-panel: Adjust panel size on plugin load/remove

### DIFF
--- a/razorqt-panel/panel/razorpanel.cpp
+++ b/razorqt-panel/panel/razorpanel.cpp
@@ -647,6 +647,8 @@ void RazorPanelPrivate::updatePluginsMinSize()
  ************************************************/
 void RazorPanelPrivate::addPlugin(const RazorPluginInfo &pluginInfo)
 {
+    Q_Q(RazorPanel);
+
     QString sectionName = pluginInfo.id();
     QStringList groups = mSettings->childGroups();
 
@@ -673,6 +675,7 @@ void RazorPanelPrivate::addPlugin(const RazorPluginInfo &pluginInfo)
 
     realign();
     saveSettings();
+    q->adjustSize();
 }
 
 
@@ -835,6 +838,8 @@ void RazorPanelPrivate::startMoveWidget()
  ************************************************/
 void RazorPanelPrivate::onRemovePlugin()
 {
+    Q_Q(RazorPanel);
+
     RazorPanelPlugin* plugin;
     PluginAction* a = qobject_cast<PluginAction*>(sender());
     if (a)
@@ -852,6 +857,7 @@ void RazorPanelPrivate::onRemovePlugin()
     mPlugins.removeAll(plugin);
     delete plugin;
     saveSettings();
+    q->adjustSize();
 }
 
 


### PR DESCRIPTION
When a plugin is, loaded or removed, the panel size should always be
adjusted. In auto mode (or theme mode) the panel should be kept to the
minimum size.

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
