### PR TITLE
Make it possible to build modules separately

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,6 @@ set( QT_USE_QTDBUS 1 )
 find_package ( Qt4 4.6.0 REQUIRED )
 include ( ${QT_USE_FILE} )
 include_directories (
-	${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}
 	${QT_QTCORE_INCLUDE_DIR} ${QT_QTGUI_INCLUDE_DIR}
 	)
 
@@ -58,24 +56,112 @@ message(STATUS "For building tests use -DBUILD_TESTS=Yes option.")
 message(STATUS "")
 
 # main build subdirs
-add_subdirectory( libraries )
-add_subdirectory( razorqt-session )
-add_subdirectory( razorqt-panel )
-add_subdirectory( razorqt-desktop )
-add_subdirectory( razorqt-appswitcher )
-add_subdirectory( razorqt-resources )
-add_subdirectory( razorqt-x11info )
-add_subdirectory( razorqt-runner )
-add_subdirectory( razorqt-config )
-add_subdirectory( razorqt-power )
-add_subdirectory( razorqt-autosuspend )
-add_subdirectory( razorqt-policykit )
-add_subdirectory( razorqt-lightdm-greeter )
-add_subdirectory( razorqt-notificationd )
-add_subdirectory( razorqt-openssh-askpass )
-add_subdirectory( razorqt-about )
-add_subdirectory( razorqt-globalkeyshortcuts )
-add_subdirectory( razorqt-confupdate )
+macro (build_module MODULE_VAR MODULE_NAME MODULE_DIR MODULE_DEFAULT)
+    if(SPLIT_BUILD)
+        set(MODULE_BUILD_DEFAULT Off)
+    else(SPLIT_BUILD)
+        set(MODULE_BUILD_DEFAULT ${MODULE_DEFAULT})
+    endif(SPLIT_BUILD)
+    option(${MODULE_VAR} ${MODULE_NAME} ${MODULE_BUILD_DEFAULT})
+    if(${MODULE_VAR})
+        #message(STATUS "Build: ${MODULE_NAME}")
+        add_subdirectory(${MODULE_DIR})
+        list(APPEND ENABLED_MODULES "${MODULE_NAME}")
+    #else()
+    #   message(STATUS "Skip:  ${MODULE_VAR}")
+    endif(${MODULE_VAR})
+endmacro()
+
+build_module(MODULE_QTXDG
+    "Qt library for XDG standards"
+    libraries/qtxdg On)
+
+build_module(MODULE_LIBRAZORQT
+    "Core Razor library"
+    libraries/razorqt On)
+
+build_module(MODULE_LIBRAZORQXT
+    "Razor global hotkey library"
+    libraries/razorqxt On)
+
+build_module(MODULE_LIBRAZORMOUNT
+    "Razor mount library"
+    libraries/razormount On)
+
+build_module(MODULE_RESOURCES
+    "Razor resources"
+    razorqt-resources On)
+
+build_module(MODULE_SESSION
+    "Razor Session manager"
+    razorqt-session On)
+
+build_module(MODULE_PANEL
+    "Razor Panel"
+    razorqt-panel On)
+
+build_module(MODULE_DESKTOP
+    "Razor Desktop"
+    razorqt-desktop On)
+
+build_module(MODULE_APPSWITCHER
+    "Razor Alt-Tab Application switcher"
+    razorqt-appswitcher On)
+
+build_module(MODULE_X11INFO
+    "X11 info"
+    razorqt-x11info Off)
+
+build_module(MODULE_RUNNER
+    "Razor Runner"
+    razorqt-runner On)
+
+build_module(MODULE_CONFIG
+    "Razor Configuration"
+    razorqt-config On)
+
+build_module(MODULE_POWER
+    "Razor power control"
+    razorqt-power On)
+
+build_module(MODULE_AUTOSUSPEND
+    "Razor Autosuspend"
+    razorqt-autosuspend On)
+
+build_module(MODULE_POLICYKIT
+    "Razor PolicyKit agent"
+    razorqt-policykit On)
+
+build_module(MODULE_LIGHTDM
+    "Razor LightDM greeter"
+    razorqt-lightdm-greeter On)
+
+build_module(MODULE_NOTIFICATIOND
+    "Razor Notifications Daemon"
+    razorqt-notificationd On)
+
+build_module(MODULE_ASKPASS
+    "SSH Askpass"
+    razorqt-openssh-askpass On)
+
+build_module(MODULE_ABOUT
+    "Razor information"
+    razorqt-about On)
+
+build_module(MODULE_GLOBALKEYSHORTCUTS
+    "Global Shortcut daemon"
+    razorqt-globalkeyshortcuts On)
+
+build_module(MODULE_CONFUPDATE
+    "Configuration updater"
+    razorqt-confupdate On)
+
+message(STATUS  "**************** The following modules will be built ****************")
+foreach (MODULE_NAME ${ENABLED_MODULES})
+    message(STATUS   "  ${MODULE_NAME}")
+endforeach()
+message(STATUS  "*********************************************************************")
+
 ########### Add uninstall target ###############
 CONFIGURE_FILE(
     "${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"

--- a/razorqt-config/razor-config-mouse/CMakeLists.txt
+++ b/razorqt-config/razor-config-mouse/CMakeLists.txt
@@ -66,7 +66,7 @@ razor_translate_desktop(DESKTOP_FILES
 add_executable ( razor-config-mouse ${razor-config-mouse_SRCS} ${razor-config-mouse_CXX} ${razor-config-mouse_MOCS} ${DESKTOP_FILES} ${QM_FILES})
 add_dependencies( razor-config-mouse razorqt qtxdg)
 target_link_libraries ( razor-config-mouse  ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTDBUS_LIBRARY} ${QT_QTXML_LIBRARY}
-                                                 ${X11_X11_LIB} ${X11_Xcursor_LIB} razorqt ${ZLIB_LIBRARY} ${X11_Xfixes_LIB})
+                                                 ${X11_X11_LIB} ${X11_Xcursor_LIB} razorqt qtxdg ${ZLIB_LIBRARY} ${X11_Xfixes_LIB})
 # not needed probably ${X11_Xfixes_LIB})
 
 INSTALL(TARGETS razor-config-mouse RUNTIME DESTINATION bin)

--- a/razorqt-config/src/CMakeLists.txt
+++ b/razorqt-config/src/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries ( razor-config
                 ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTXML_LIBRARY}
                 qtxdg razorqt)
 # helper static lib
-link_directories(./qcategorizedview)
+link_directories(${CMAKE_CURRENT_SOURCE_DIR}/qcategorizedview)
 target_link_libraries( razor-config qcategorizedview)
 
 INSTALL(TARGETS razor-config RUNTIME DESTINATION bin)


### PR DESCRIPTION
This provides CMake switches to build different components separately per issue #409.

`SPLIT_BUILD` disables everything by default, and `MODULE_...` control which modules are built.

So, to build just the QtXDG library:

```
cmake .. -DSPLIT_BUILD=On -DMODULE_QTXDG=On
```
