### PR TITLE
Clock panel plugin theme fixed

### DIFF
--- a/razorqt-resources/themes/a-mego/razor-panel.qss
+++ b/razorqt-resources/themes/a-mego/razor-panel.qss
@@ -91,13 +91,10 @@ RazorPanelPlugin > QToolButton:hover{
 /*
  * Clock
  */
-#Clock > ClockLabel{
-	font-size: 10pt;
-}
-
 #Clock > QWidget > QLabel{
-	margin-right: 2px;
-	color: #606060;
+    font-size: 10pt;
+    margin-right: 2px;
+    color: #606060;
 }
 
 /*

--- a/razorqt-resources/themes/ambiance/razor-panel.qss
+++ b/razorqt-resources/themes/ambiance/razor-panel.qss
@@ -95,13 +95,10 @@ RazorPanelPlugin > QToolButton:hover{
 /*
  * Clock
  */
-#Clock > ClockLabel{
-    font-size: 10pt;
-}
-
 #Clock > QWidget > QLabel{
-	margin-right: 2px;
-	color: #F2F1F0;
+    font-size: 10pt;
+    margin-right: 2px;
+    color: #F2F1F0;
 }
 
 /*

--- a/razorqt-resources/themes/green/razor-panel.qss
+++ b/razorqt-resources/themes/green/razor-panel.qss
@@ -103,7 +103,7 @@ RazorPanel[position="1"] #DesktopSwitch QToolButton
 /*
  * Clock
  */
-#Clock QLabel {
+#Clock > QWidget > QLabel {
     font-size: 8pt;
     color: #606060;
 }

--- a/razorqt-resources/themes/light/razor-panel.qss
+++ b/razorqt-resources/themes/light/razor-panel.qss
@@ -103,7 +103,7 @@ RazorPanel[position="1"] #DesktopSwitch QToolButton
 /*
  * Clock
  */
-#Clock QLabel {
+#Clock > QWidget > QLabel {
     font-size: 8pt;
     color: #606060;
 }


### PR DESCRIPTION
QLabels on clock configuration dialog aren't affected by theme style any more.
