### PR TITLE
Custom font for clock plugin applied correctly

### DIFF
--- a/razorqt-panel/plugin-clock/razorclock.cpp
+++ b/razorqt-panel/plugin-clock/razorclock.cpp
@@ -62,7 +62,7 @@ RazorClock::RazorClock(const RazorPanelPluginStartInfo* startInfo, QWidget* pare
     setObjectName("Clock");
     clockFormat = "hh:mm";
 
-    fakeThemedLabel = new ClockLabel(this);
+    fakeThemedLabel = new ClockLabel(content);
     fakeThemedLabel->setVisible(false);
 
     timeLabel = new QLabel(this);


### PR DESCRIPTION
When panel clock plugin is used with custom fonts, they aren't applied correclty on panel start due to conflict and race condition with qss theme. When settings are changed fonts are set correctly.

Using delayed initialisation this patch fixes the problem.
