### PR TITLE
Fix CMakeLists.txt for 'Unknown CMake command "razor_translate_ts" in razorqt-notificationd

### DIFF
--- a/q
+++ b/q
@@ -1,0 +1,11 @@
+total 48
+drwxr-xr-x  2 francisco francisco  4096 oct 14 00:19 ./
+drwxr-xr-x 27 francisco francisco  4096 oct 21 15:03 ../
+-rw-r--r--  1 francisco francisco  2840 oct 14 00:19 FindPulseAudio.cmake
+-rw-r--r--  1 francisco francisco  1798 oct 14 00:19 FindUDev.cmake
+-rw-r--r--  1 francisco francisco  1335 oct 14 00:19 RazorInstallConfigPath.cmake
+-rw-r--r--  1 francisco francisco  1344 oct 14 00:19 RazorLibSuffix.cmake
+-rw-r--r--  1 francisco francisco 10178 oct 14 00:19 RazorTranslate.cmake
+-rw-r--r--  1 francisco francisco   792 oct 14 00:19 cmake_uninstall.cmake.in
+-rw-r--r--  1 francisco francisco   715 oct 14 00:19 create_pkgconfig_file.cmake
+-rw-r--r--  1 francisco francisco   733 oct 14 00:19 razortranslate.h.in

--- a/razorqt-notificationd/src/CMakeLists.txt
+++ b/razorqt-notificationd/src/CMakeLists.txt
@@ -33,6 +33,7 @@ qt4_add_dbus_adaptor(NOTIFICATIONS_SRC
 )
 
 # Translations **********************************
+include(RazorTranslate)
 razor_translate_ts(NOTIFICATIONS_QM_FILES
     SOURCES
         ${NOTIFICATIONS_MOC}


### PR DESCRIPTION
When trying to compile razor-notifications throws the following error:

CMake Error at razorqt-notificationd/src/CMakeLists.txt:36 (razor_translate_ts):
  Unknown CMake command "razor_translate_ts".

-- Configuring incomplete, errors occurred!
- ERROR: razorqt-base/razorqt-notifications-9999 failed (configure phase):
-   cmake failed

I use Gentoo, and git razor
