### PR TITLE
Added debian root menu entries for debian compilants

### DIFF
--- a/distr/deb/debian/librazorqt0.menu
+++ b/distr/deb/debian/librazorqt0.menu
@@ -1,2 +1,2 @@
 ?package(librazorqt0):needs="X11" section="Applications/System"\
-  title="VNXDE Razor-Qt information" command="/usr/bin/razor-about"
+  title="Razor-qt information" command="/usr/bin/razor-about"

--- a/distr/deb/debian/razorqt-autosuspend.menu
+++ b/distr/deb/debian/razorqt-autosuspend.menu
@@ -1,2 +1,2 @@
 ?package(razorqt-autosuspend):needs="X11" section="Applications/System"\
-  title="Razor-Qt suspend config" command="/usr/bin/razor-config-autosuspend"
+  title="Razor-qt suspend settings" command="/usr/bin/razor-config-autosuspend"

--- a/distr/deb/debian/razorqt-config.menu
+++ b/distr/deb/debian/razorqt-config.menu
@@ -1,9 +1,9 @@
 ?package(razorqt-config):needs="X11" section="Applications/System"\
-  title="Razor-Qt all settings" command="/usr/bin/razor-config"
+  title="Razor-qt settings center" command="/usr/bin/razor-config"
 
 ?package(razorqt-config):needs="X11" section="Applications/System"\
-  title="Razor-Qt mouse settings" command="/usr/bin/razor-config-mouse"
+  title="Razor-qt mouse settings" command="/usr/bin/razor-config-mouse"
 
 ?package(razorqt-config):needs="X11" section="Applications/System"\
-  title="Razor-Qt gui settings" command="/usr/bin/razor-config-appearance"
+  title="Razor-qt gui settings" command="/usr/bin/razor-config-appearance"
 

--- a/distr/deb/debian/razorqt-desktop.menu
+++ b/distr/deb/debian/razorqt-desktop.menu
@@ -1,5 +1,5 @@
 ?package(razorqt-desktop):needs="X11" section="Applications/Viewers"\
-  title="Razor-Qt desktop" command="/usr/bin/razor-desktop"
+  title="Razor-qt desktop manager" command="/usr/bin/razor-desktop"
 
 ?package(razorqt-desktop):needs="X11" section="Applications/System"\
-  title="Razor-Qt desktop settings" command="/usr/bin/razor-config-desktop"
+  title="Razor-qt desktop settings" command="/usr/bin/razor-config-desktop"

--- a/distr/deb/debian/razorqt-globalkeyshortcuts.menu
+++ b/distr/deb/debian/razorqt-globalkeyshortcuts.menu
@@ -1,2 +1,2 @@
 ?package(razorqt-globalkeyshortcuts):needs="X11" section="Applications/System"\
-  title="Razor-Qt suspend config" command="/usr/bin/razor-config-globalkeyshortcuts"
+  title="Razor-qt shorcuts settings" command="/usr/bin/razor-config-globalkeyshortcuts"

--- a/distr/deb/debian/razorqt-notificationd.menu
+++ b/distr/deb/debian/razorqt-notificationd.menu
@@ -1,2 +1,2 @@
 ?package(razorqt-notificationd):needs="X11" section="Applications/System"\
-  title="Razor-Qt Notification settings" command="/usr/bin/razor-config-notificationd"
+  title="Razor-qt Notification settings" command="/usr/bin/razor-config-notificationd"

--- a/distr/deb/debian/razorqt-panel.menu
+++ b/distr/deb/debian/razorqt-panel.menu
@@ -1,2 +1,2 @@
 ?package(razorqt-panel):needs="X11" section="Applications/Tools"\
-  title="Razor-Qt panel" command="/usr/bin/razor-panel"
+  title="Razor-qt panel" command="/usr/bin/razor-panel"

--- a/distr/deb/debian/razorqt-session.menu
+++ b/distr/deb/debian/razorqt-session.menu
@@ -1,2 +1,2 @@
 ?package(razorqt-session):needs="X11" section="Applications/System"\
-  title="Razor-Qt session settings" command="/usr/bin/razor-config-session"
+  title="Razor-qt session settings" command="/usr/bin/razor-config-session"


### PR DESCRIPTION
Debian has a menu system, for common desktop integration, these entries are missing in package, so now provide.

debhelper v7+ will handle and install in right place at dh_installmenu commnd step.
