### PR TITLE
panel-volume: add compile time switch for ALSA/Pulseaudio support

### DIFF
--- a/razorqt-panel/CMakeLists.txt
+++ b/razorqt-panel/CMakeLists.txt
@@ -33,7 +33,12 @@ setByDefault(HELLOWORLD_PLUGIN No)
 setByDefault(CPULOAD_PLUGIN Yes)
 setByDefault(NETWORKMONITOR_PLUGIN Yes)
 setByDefault(SENSORS_PLUGIN Yes)
+
 setByDefault(VOLUME_PLUGIN Yes)
+# Options for the volume plugin.
+setByDefault(VOLUME_USE_PULSEAUDIO Yes)
+setByDefault(VOLUME_USE_ALSA Yes)
+
 setByDefault(KBINDICATOR_PLUGIN Yes)
 setByDefault(SYSSTAT_PLUGIN Yes)
 # *******************************************************************
@@ -164,8 +169,13 @@ if (SENSORS_PLUGIN)
 endif (SENSORS_PLUGIN)
 
 if (VOLUME_PLUGIN)
-  FIND_PACKAGE(PulseAudio)
-  FIND_PACKAGE(ALSA)
+  if (VOLUME_USE_PULSEAUDIO)
+    FIND_PACKAGE(PulseAudio)
+  endif (VOLUME_USE_PULSEAUDIO)
+
+  if (VOLUME_USE_ALSA)
+    FIND_PACKAGE(ALSA)
+  endif (VOLUME_USE_ALSA)
 
   if (PULSEAUDIO_FOUND OR ALSA_FOUND)
     set(ENABLED_PLUGINS ${ENABLED_PLUGINS}   "Volume")


### PR DESCRIPTION
This commit adds a compile time option to enable/disable ALSA/PulseAudio support.
Previously one of them or both were linked to if they were found on the system, provided that volume plugin was enabled.
This commit doesn't change the default behaviour.
It's useful for distributions; it has already been integrated in Gentoo.

Tested with 0.5.1, behaves correctly with all relevant combination of options, then backported to master branch, where I've examined output with various options combination - all fine.

Thanks!
