### PR TITLE
Remove ~/razor

### DIFF
--- a/razorqt-confupdate/updates/razor-0.5/razor-0.5.upd
+++ b/razorqt-confupdate/updates/razor-0.5/razor-0.5.upd
@@ -1,21 +1,21 @@
 Id=razor_0.4.1-0.5.0
 
-File=~/.razor/session.conf,razor/session.conf
+File=~/.razor/session.conf
 Options=copy
 Script=sesion_modules
 
-File=~/.razor/desktop.conf,razor/desktop.conf
+File=~/.razor/desktop.conf
 Options=copy
 Script=desktop-041-050.py,python
 
-File=~/.razor/razor.conf,razor/razor.conf
+File=~/.razor/razor.conf
 Options=copy
 AllKeys
 
-File=~/.razor/razor-runner.conf,razor/razor-runner.conf
+File=~/.razor/razor-runner.conf
 Options=copy
 AllKeys
 
-File=~/.razor/razor-panel/panel.conf,razor/razor-panel/panel.conf
+File=~/.razor/razor-panel/panel.conf
 Options=copy
 AllKeys


### PR DESCRIPTION
All existing code seems to reference .razor, as it should, thus this creation of razor/\* is superfluous and is incompliant with the LSB (http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html). This commit addresses part of Issue 492.
