### PR TITLE
plugin-mount: Don't add devices that are not usable

### DIFF
--- a/razorqt-panel/plugin-mount/menudiskitem.cpp
+++ b/razorqt-panel/plugin-mount/menudiskitem.cpp
@@ -82,9 +82,6 @@ void MenuDiskItem::update()
     diskButton->setText(label);
 
     setMountStatus(mDevice->isMounted());
-
-
-    this->setVisible(isUsableDevice(mDevice));
 }
 
 

--- a/razorqt-panel/plugin-mount/mountbutton.cpp
+++ b/razorqt-panel/plugin-mount/mountbutton.cpp
@@ -67,9 +67,16 @@ Popup::Popup(RazorMountManager *manager, QWidget* parent):
 
 MenuDiskItem *Popup::addItem(RazorMountDevice *device)
 {
-    MenuDiskItem  *item   = new MenuDiskItem(device, this);
-    layout()->addWidget(item);
-    return item;
+    if (MenuDiskItem::isUsableDevice(device))
+    {
+        MenuDiskItem  *item   = new MenuDiskItem(device, this);
+        layout()->addWidget(item);
+        return item;
+    }
+    else
+    {
+        return 0;
+    }
 }
 
 


### PR DESCRIPTION
The disk items shown to the user are the one that are usable
( see  MenuDiskItem::isUsableDevice() ). When a new item is added, it is
shown only if it's an usable one. But when initializing MenuDiskItem
all the devices from the device list are actually added without filtering.
The user can't see them, because they are set to not visible, if they are
not usable. That's a waste of memory.

p.s. ABI compatible 
