### PR TITLE
plugin-clock: Don't try to get the firstDayofWeek from saved settings

### DIFF
--- a/razorqt-panel/plugin-clock/razorclock.cpp
+++ b/razorqt-panel/plugin-clock/razorclock.cpp
@@ -93,6 +93,8 @@ RazorClock::RazorClock(const RazorPanelPluginStartInfo* startInfo, QWidget* pare
     connect (mClockTimer, SIGNAL(timeout()), SLOT(updateTime()));
     mClockTimer->start(1000);
 
+    mFirstDayOfWeek = firstDayOfWeek();
+
     settingsChanged();
 }
 
@@ -146,8 +148,6 @@ void RazorClock::settingsChanged()
         mClockFormat = QString("%1 %2").arg(mTimeFormat).arg(mDateFormat);
     else
         mClockFormat = mTimeFormat;
-
-    mFirstDayOfWeek = static_cast<Qt::DayOfWeek>(settings().value("firstDayOfWeek", firstDayOfWeek()).toInt());
 
     mDateLabel->setVisible(mDateOnNewLine);
 


### PR DESCRIPTION
The firstDayofWeek is computed now. It's not part of the saved settings.
LC_TIME locale is only set one time, so let's move it to the constructor.

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
