### PR TITLE
Make it possible for translations for multiple libs to be loaded

### DIFF
--- a/libraries/razorqt/libtranslate.h
+++ b/libraries/razorqt/libtranslate.h
@@ -31,10 +31,19 @@
 #include <QtCore/QTranslator>
 #include <QtCore/QCoreApplication>
 #include <QtCore/QLocale>
+#include <QtCore/QMutex>
 
 inline void libTranslate(const QString &name)
 {
-    static bool alreadyLoaded = false;
+    static QMutex mutex;
+    static QList<QString> libs;
+
+    mutex.lock();
+    bool alreadyLoaded = libs.contains(name);
+    if (!alreadyLoaded)
+        libs.append(name);
+    mutex.unlock();
+
     if (alreadyLoaded)
         return;
 
@@ -43,7 +52,6 @@ inline void libTranslate(const QString &name)
     translator->load(QString("%1/%2_%3.qm").arg(TRANSLATIONS_DIR, name, locale));
 
     QCoreApplication::installTranslator(translator);
-    alreadyLoaded = true;
 }
 
 


### PR DESCRIPTION
I updated translations today and found that when razor-desktop does `libTranslate("desktop-razor")`, it no longer loads translations for librazorqt because it's already marked as loaded. As a result, the Shutdown/Reboot part of the desktop menu ends up being untranslated.

This fixes it, but I'm not sure if this is the best way.
