### PR TITLE
Fix underlinking with QtDbus

### DIFF
--- a/razorqt-autosuspend/config/CMakeLists.txt
+++ b/razorqt-autosuspend/config/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries ( razor-config-autosuspend
                         razorqt 
                         ${QT_QTCORE_LIBRARY} 
                         ${QT_QTGUI_LIBRARY}  
+                        ${QT_QTDBUS_LIBRARY}
                       )
 
 


### PR DESCRIPTION
It fails to build on Gentoo due to underlinking with QtDbus. The patch fixes it .
