### PR TITLE
Make config center icon labels not wrap as much

### DIFF
--- a/razorqt-config/src/mainwindow.cpp
+++ b/razorqt-config/src/mainwindow.cpp
@@ -31,6 +31,7 @@
 #include "mainwindow.h"
 #include <QtDebug>
 #include <QtGui/QMessageBox>
+#include <QtGui/QStyledItemDelegate>
 
 #include <qtxdg/xdgdesktopfile.h>
 #include <qtxdg/xdgicon.h>
@@ -161,6 +162,37 @@ private:
 }
 
 
+class ConfigItemDelegate : public QStyledItemDelegate
+{
+public:
+    ConfigItemDelegate(QCategorizedView* view) : mView(view) { }
+    ~ConfigItemDelegate() { }
+
+    QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const
+    {
+        int height = QStyledItemDelegate::sizeHint(option, index).height();
+        return QSize(mView->gridSize().width(), qMin(height, mView->gridSize().height()));
+    }
+
+protected:
+    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+    {
+        QStyleOptionViewItemV4 opt = option;
+        initStyleOption(&opt, index);
+
+        QSize size(mView->gridSize().width(), mView->iconSize().height());
+        QPixmap pixmap = opt.icon.pixmap(mView->iconSize());
+        opt.icon = QIcon(pixmap.copy(QRect(QPoint(0, 0), size)));
+        opt.decorationSize = size;
+
+        QApplication::style()->drawControl(QStyle::CE_ItemViewItem, &opt, painter);
+    }
+
+private:
+    QCategorizedView *mView;
+};
+
+
 RazorConfig::MainWindow::MainWindow() : QMainWindow()
 {
     setupUi(this);
@@ -179,6 +211,7 @@ RazorConfig::MainWindow::MainWindow() : QMainWindow()
     proxyModel->setSourceModel(model);
 
     view->setModel(proxyModel);
+    view->setItemDelegate(new ConfigItemDelegate(view));
 
     connect(view, SIGNAL(activated(const QModelIndex&)),
             this, SLOT(activateItem(const QModelIndex&)));


### PR DESCRIPTION
This is a fix to a problem reported by our Thai translator here:
https://groups.google.com/group/razor-qt/browse_frm/thread/a1173d2c201c59e7

It looks like Qt wraps text around the width of the icon, and does not try to use up all the available horizontal space. To fix it, I'm increasing the width of the icon to the width of the grid.

It's a hack, but I'm out of other ideas. Anyone know how to do it better?

Before:
![aaa](https://f.cloud.github.com/assets/79843/46385/70058484-5854-11e2-87df-2ba181ef8b40.png)

After:
![TOlfB](https://f.cloud.github.com/assets/79843/46382/fa3a5e6e-5853-11e2-9ac8-36f60b12cfd2.png)
