### PR TITLE
Incorrect size descriptor used

### DIFF
--- a/libraries/razormount/razormount.cpp
+++ b/libraries/razormount/razormount.cpp
@@ -42,15 +42,15 @@ QString RazorMountDevice::sizeToString(qulonglong size)
 {
     double n;
     n = size / (1024.0 * 1024 * 1024);
-    if (n > 0)
+    if (n >= 1.0)
         return QObject::tr("%1 GB").arg(n, 0, 'f', 1);
 
     n = size / (1024.0 * 1024);
-    if (n > 0)
+    if (n >= 1.0)
         return QObject::tr("%1 MB").arg(n, 0, 'f', 1);
 
     n = size / (1024.0);
-    if (n > 0)
+    if (n >= 1.0)
         return QObject::tr("%1 KB").arg(n, 0, 'f', 1);
 
     return QObject::tr("%1 B").arg(size);


### PR DESCRIPTION
One of previous bugfixes (https://github.com/Razor-qt/razor-qt/issues/522) brought another bug. For size expression was used GB only. Reason was incorrect comparison.
