### PR TITLE
ignored duplicate entries in the HistoryProvider

### DIFF
--- a/razorqt-runner/providers.cpp
+++ b/razorqt-runner/providers.cpp
@@ -380,8 +380,21 @@ HistoryProvider::~HistoryProvider()
  ************************************************/
 void HistoryProvider::AddCommand(const QString &command)
 {
-    HistoryItem *item = new HistoryItem(command);
-    insert(0, item);
+    bool commandExists = false;
+    for (int i=0; !commandExists && i<length(); ++i)
+    {
+        if (command == static_cast<HistoryItem*>(at(i))->command())
+        {
+            move(i, 0);
+            commandExists = true;
+        }
+    }
+
+    if (!commandExists)
+    {
+        HistoryItem *item = new HistoryItem(command);
+        insert(0, item);
+    }
 
     mHistoryFile->clear();
     for (int i=0; i<qMin(length(), MAX_HISTORY); ++i)


### PR DESCRIPTION
Currently razorqt-runner can produce duplicates in the history:
if you run the same command from the CustomCommandProvider twice, it
will be inserted into the HistoryProvider-list and the file twice.

This patch checks changes HistoryProvider::AddCommand, so that it will
search if this command already exists and it will move that entry to
the top of the list (instead of creating a new item).

Additionally I added a check to HistoryProvider::HistoryProvider to
filter duplicates from the history-cache-file. Of course the addition to
HistoryProvider::AddCommand alone will guarantee that no duplicates
exist, so this filter is only be needed if you upgrade from older
versions of razorqt-runner and you already have duplicates in your
history.

(I tested this on top of the tag for 0.5.2 and the current master)
