### PR TITLE
Taskbar button height fix in vertical panel layout

### DIFF
--- a/razorqt-panel/plugin-taskbar/razortaskbar.cpp
+++ b/razorqt-panel/plugin-taskbar/razortaskbar.cpp
@@ -90,7 +90,7 @@ RazorTaskBar::~RazorTaskBar()
  ************************************************/
 void RazorTaskBar::updateSizePolicy()
 {
-    QSizePolicy sp(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    QSizePolicy sp(QSizePolicy::Expanding, panel()->isHorizontal() ? QSizePolicy::Expanding : QSizePolicy::Fixed);
     sp.setHorizontalStretch(1);
     sp.setVerticalStretch(1);
     setSizePolicy(sp);


### PR DESCRIPTION
When razor-panel is vertical every taskbar button is expanded verticaly. Here is the small fix.
Before:
![before](https://f.cloud.github.com/assets/101042/212743/31e2d9b0-832c-11e2-8bce-f9f768174eed.png)
After:
![after](https://f.cloud.github.com/assets/101042/212744/37b60f24-832c-11e2-8188-b1e97772a3d1.png)
