### PR TITLE
Libraries Cmake maintenance

### DIFF
--- a/libraries/qtxdg/CMakeLists.txt
+++ b/libraries/qtxdg/CMakeLists.txt
@@ -79,7 +79,6 @@ qtxdg_translate_ts(libqtxdg_QM_FILES
 
 #**********************************************************
 
-include(RazorLibSuffix)
 
 QT4_WRAP_CPP(libqtxdg_CXX_FILES ${libqtxdg_MOCS})
 

--- a/libraries/razormount/CMakeLists.txt
+++ b/libraries/razormount/CMakeLists.txt
@@ -24,7 +24,6 @@ set(razormount_MOCS
 
 QT4_WRAP_CPP(razourmount_MOCS ${razormount_MOCS})
 
-#include(RazorLibSuffix)
 
 add_library ( razormount SHARED ${razormount_SRCS} ${razourmount_MOCS} )
 

--- a/libraries/razorqt/CMakeLists.txt
+++ b/libraries/razorqt/CMakeLists.txt
@@ -123,7 +123,6 @@ QT4_WRAP_CPP(MOCS ${razorqt_MOCS})
 QT4_WRAP_UI(UIS ${razorqt_UIS})
 
 
-include(RazorLibSuffix)
 
 include(translatorsinfo/CMakeLists.txt)
 get_translatorsinfo_qrc(translatorsinfo_qrc)

--- a/libraries/razorqxt/CMakeLists.txt
+++ b/libraries/razorqxt/CMakeLists.txt
@@ -1,4 +1,3 @@
-include(RazorLibSuffix)
 
 find_package(X11 REQUIRED)
 include_directories(${X11_INCLUDE_DIR})

--- a/libraries/sysstat/CMakeLists.txt
+++ b/libraries/sysstat/CMakeLists.txt
@@ -57,7 +57,6 @@ file(GLOB SYSSTAT_TS_FILES
 
 #**********************************************************
 
-include(RazorLibSuffix)
 
 QT4_WRAP_CPP(SYSSTAT_CXX ${SYSSTAT_MOCS})
 qt4_add_translation(SYSSTAT_QM_FILES ${SYSSTAT_TS_FILES})


### PR DESCRIPTION
I'm performing some maintenance on the build system to ease the support for Qt5. Just the libraries by now. There's duplicated things that now only slow down the configuration phase. But some of them will require extra effort to support Qt5. Ex: unneeded find_package(Qt4)

Check this little [post](https://groups.google.com/d/topic/razor-qt/g6ikl01jfnc/discussion)
