### PR TITLE
Fix 'Unknown CMake command "razor_translate_ts"' error.

### DIFF
--- a/razorqt-globalkeyshortcuts/config/CMakeLists.txt
+++ b/razorqt-globalkeyshortcuts/config/CMakeLists.txt
@@ -110,6 +110,7 @@ endif()
 #endif()
 
 # Translations **********************************
+include(RazorTranslate)
 razor_translate_ts(${PROJECT_NAME}_QM_FILES
 	SOURCES
 	${${PROJECT_NAME}_TRANSLATABLE}


### PR DESCRIPTION
This error message is produced by configuring with -DSPLIT_BUILD=On -DMODULE_GLOBALKEYSHORTCUTS=On:

-- Found Qt4: /usr/bin/qmake (found version "4.8.4") 
CMake Error at razorqt-globalkeyshortcuts/config/CMakeLists.txt:113 (razor_translate_ts):
  Unknown CMake command "razor_translate_ts".
