### PR TITLE
fix the underlinking of lightdm greeter

### DIFF
--- a/razorqt-lightdm-greeter/CMakeLists.txt
+++ b/razorqt-lightdm-greeter/CMakeLists.txt
@@ -93,7 +93,7 @@ if (ENABLE_LIGHTDM_GREETER)
                             ${QM_FILES}
                             ${MOCS}
                     )
-        target_link_libraries ( razor-lightdm-greeter  razorqt ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTDBUS_LIBRARY} ${QT_QTNETWORK_LIBRARY} ${LIGHTDM_QT_LIBRARIES} )
+        target_link_libraries ( razor-lightdm-greeter  razorqt qtxdg ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTDBUS_LIBRARY} ${QT_QTNETWORK_LIBRARY} ${LIGHTDM_QT_LIBRARIES} )
 
         file(GLOB DESKTOP_FILES resources/*.desktop)
         file(GLOB CONFIG_FILES resources/*.conf)


### PR DESCRIPTION
The lightdm greeter fails to link in the split build mode:

/usr/lib/gcc/x86_64-pc-linux-gnu/4.7.3/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/razor-lightdm-greeter.dir/logindata.cpp.o: undefined reference to symbol '_ZN7XdgDirs9cacheHomeEb'
/usr/lib/gcc/x86_64-pc-linux-gnu/4.7.3/../../../../x86_64-pc-linux-gnu/bin/ld: note: '_ZN7XdgDirs9cacheHomeEb' is defined in DSO /usr/lib64/libqtxdg.so.0 so try adding it to the linker command line
/usr/lib64/libqtxdg.so.0: could not read symbols: Invalid operation
