### PR TITLE
razorqt-panel/panel: Save settings right after the close button clicked

### DIFF
--- a/razorqt-panel/panel/config/configpaneldialog.cpp
+++ b/razorqt-panel/panel/config/configpaneldialog.cpp
@@ -77,6 +77,7 @@ ConfigPanelDialog::ConfigPanelDialog(RazorPanel *panel, QWidget *parent):
     ConfigPanelWidget* page = new ConfigPanelWidget(panel, this);
     addPage(page, tr("Configure panel"));
     connect(this, SIGNAL(reset()), page, SLOT(reset()));
+    connect(this, SIGNAL(accepted()), panel, SLOT(saveSettings(false)));
 }
 
 


### PR DESCRIPTION
The panel settings are saved in a delayed mode. But... when the user clicks
the Close button the settings should be saved right way. This is useful
for the developer. A developer may kill the panel before the settings are
actually saved and that can confuse the developer.

Signed-off-by: Luís Pereira luis.artur.pereira@gmail.com
