### PR TITLE
razorqt-desktop: Unify plugins and widgets names. Closes #447

### DIFF
--- a/libraries/razorqt/addplugindialog/addplugindialog.ui
+++ b/libraries/razorqt/addplugindialog/addplugindialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Add plugins</string>
+   <string>Add Desktop Widgets</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/razorqt-desktop/desktop-razor/desktopscene.cpp
+++ b/razorqt-desktop/desktop-razor/desktopscene.cpp
@@ -93,11 +93,11 @@ DesktopScene::DesktopScene(QObject * parent)
     connect(m_actAddNewPlugin, SIGNAL(triggered()),
             this, SLOT(showAddPluginDialog()));
 
-    m_actRemovePlugin = new QAction(tr("Remove Plugin..."), this);
+    m_actRemovePlugin = new QAction(tr("Remove Desktop Widget..."), this);
     connect(m_actRemovePlugin, SIGNAL(triggered()),
             this, SLOT(removePlugin()));
 
-    m_actConfigurePlugin = new QAction(tr("Configure Plugin..."), this);
+    m_actConfigurePlugin = new QAction(tr("Configure Desktop Widget..."), this);
     connect(m_actConfigurePlugin, SIGNAL(triggered()),
             this, SLOT(configurePlugin()));
 


### PR DESCRIPTION
Widgets is a more user oriented name.
