### PR TITLE
Special meaning of negative size for panel

### DIFF
--- a/razorqt-panel/panel/config/configpaneldialog.cpp
+++ b/razorqt-panel/panel/config/configpaneldialog.cpp
@@ -261,14 +261,14 @@ void ConfigPanelWidget::widthTypeChanged()
     {
         // Percents .............................
         int v = ui->spinBox_length->value() * 100.0 / max;
-        ui->spinBox_length->setMaximum(100);
+        ui->spinBox_length->setRange(1, 100);
         ui->spinBox_length->setValue(v);
     }
     else
     {
         // Pixels ...............................
         int v =  max / 100.0 * ui->spinBox_length->value();
-        ui->spinBox_length->setMaximum(max);
+        ui->spinBox_length->setRange(-max, max);
         ui->spinBox_length->setValue(v);
     }
 }

--- a/razorqt-panel/panel/razorpanel.cpp
+++ b/razorqt-panel/panel/razorpanel.cpp
@@ -324,7 +324,12 @@ void RazorPanel::realign()
         if (mLengthInPercents)
             rect.setWidth(screen.width() * mLength / 100.0);
         else
-            rect.setWidth(mLength);
+        {
+            if (mLength <= 0)
+                rect.setWidth(screen.width() + mLength);
+            else
+                rect.setWidth(mLength);
+        }
 
         rect.setWidth(qMax(rect.size().width(), mLayout->minimumSize().width()));
 
@@ -359,7 +364,12 @@ void RazorPanel::realign()
         if (mLengthInPercents)
             rect.setHeight(screen.height() * mLength / 100.0);
         else
-            rect.setHeight(mLength);
+        {
+            if (mLength <= 0)
+                rect.setHeight(screen.height() + mLength);
+            else
+                rect.setHeight(mLength);
+        }
 
         rect.setHeight(qMax(rect.size().height(), mLayout->minimumSize().height()));
 


### PR DESCRIPTION
When I use another monitor with my laptop, my secondary panel (a vertical one with size = screen.height() -main_panel.height()) becomes shorter since its size specified in pixels. So I have to adjust the height, then when I unplug it and use laptop's monitor only, this panel becomes bigger than screen size so I have to adjust the height again.
This patch allows negative panel lengths in pixels and applies a special meaning to it: if the length value is negative or zero, then the panel length is maximum available space (screen width or height) - specified value.
