### PR TITLE
Prevent double forking when launching processes

### DIFF
--- a/libraries/qtxdg/xdgdesktopfile.cpp
+++ b/libraries/qtxdg/xdgdesktopfile.cpp
@@ -54,6 +54,7 @@
 #include <QSettings>
 #include <QTextStream>
 #include <QFile>
+#include <QObject>
 /************************************************
 
  ************************************************/
@@ -360,7 +361,10 @@ bool XdgDesktopFileData::startApplicationDetached(const XdgDesktopFile *q, const
     }
 
     QString cmd = args.takeFirst();
-    return QProcess::startDetached(cmd, args);
+    QProcess* proc = new QProcess();
+    QObject::connect(proc,SIGNAL(finished(int)),proc,SLOT(deleteLater()));
+    proc->start(cmd, args);
+    return true;
 }
 
 

--- a/razorqt-globalkeyshortcuts/src/command_action.cpp
+++ b/razorqt-globalkeyshortcuts/src/command_action.cpp
@@ -28,6 +28,7 @@
 #include "command_action.h"
 
 #include <QProcess>
+#include <QObject>
 
 #include <errno.h>
 #include <string.h>
@@ -50,11 +51,9 @@ bool CommandAction::call()
         return false;
     }
 
-    bool result = QProcess::startDetached(mCommand, mArgs);
-    if (!result)
-    {
-        mLogTarget->log(LOG_WARNING, "Failed to launch command \"%s\"%s", qPrintable(mCommand), qPrintable(joinToString(mArgs, " \"", "\" \"", "\"")));
-    }
+    QProcess* proc = new QProcess();
+    QObject::connect(proc, SIGNAL(finished(int)), proc, SLOT(deleteLater()));
+    proc->start(mCommand, mArgs);
 
-    return result;
+    return true;
 }

--- a/razorqt-panel/plugin-quicklaunch/quicklaunchaction.cpp
+++ b/razorqt-panel/plugin-quicklaunch/quicklaunchaction.cpp
@@ -115,8 +115,12 @@ void QuickLaunchAction::execAction()
     switch (m_type)
     {
         case ActionLegacy:
-            QProcess::startDetached(exec);
+	{
+            QProcess* proc = new QProcess();
+	    connect(proc, SIGNAL(finished(int)), proc, SLOT(deleteLater()));
+	    proc->start(exec);
             break;
+	}
         case ActionXdg:
         {
             XdgDesktopFile * xdg = XdgDesktopFileCache::getFile(exec);


### PR DESCRIPTION
Hello,
launching processes using QProcess::start() method instead of QProcess::startDetached() prevents the double forking issue.

(author colin@mageia.org)
